### PR TITLE
BUGFIX: hreflang attribute should contain valid HTML language tags

### DIFF
--- a/Resources/Private/Templates/TypoScriptObjects/AlternateLanguageLinks.html
+++ b/Resources/Private/Templates/TypoScriptObjects/AlternateLanguageLinks.html
@@ -1,3 +1,4 @@
 {namespace neos=TYPO3\Neos\ViewHelpers}
+{namespace ts=TYPO3\TypoScript\ViewHelpers}
 <f:for each="{items}" as="item"><f:if condition="{item.node}">
-<link rel="alternate" hreflang="{item.preset.values.0}" href="{neos:uri.node(node : item.node, absolute: true)}"/></f:if></f:for>
+<link rel="alternate" hreflang="{ts:render(path: 'localeToLanguage', context: {item: item})}" href="{neos:uri.node(node : item.node, absolute: true)}"/></f:if></f:for>

--- a/Resources/Private/TypoScript/Root.ts2
+++ b/Resources/Private/TypoScript/Root.ts2
@@ -5,7 +5,7 @@
 prototype(TYPO3.Neos:Page) {
 	htmlTag {
 		attributes {
-			lang = ${q(documentNode.context.dimensions.language).first().get()}
+			lang = ${String.replace(documentNode.context.dimensions.language[0], '_', '-')}
 			lang.@if.languageDimensionExists = ${Configuration.setting('TYPO3.TYPO3CR.contentDimensions.language') != null}
 			lang.@if.onlyRenderWhenInLiveWorkspace = ${node.context.workspace.name == 'live'}
 		}
@@ -67,6 +67,9 @@ prototype(TYPO3.Neos:Page) {
 		alternateLanguageLinks = TYPO3.Neos:DimensionMenu {
 			@if.languageDimensionExists = ${Configuration.setting('TYPO3.TYPO3CR.contentDimensions.language') != null}
 			@if.onlyRenderWhenInLiveWorkspace = ${node.context.workspace.name == 'live'}
+
+			localeToLanguage = ${String.replace(item.preset.values[0], '_', '-')}
+
 			dimension = 'language'
 			templatePath = 'resource://TYPO3.Neos.Seo/Private/Templates/TypoScriptObjects/AlternateLanguageLinks.html'
 		}


### PR DESCRIPTION
The alternate language links and the html lang attribute contain
the configured values for the ``language`` dimension if it exists.
We assume a valid locale to be separated by underscores as in
``is_IS`` for icelandic spoken on iceland. HTML expects this
separated with dashes though so we need to convert this on output.

NEOS-1344 #close