### PR TITLE
BUGFIX: Adopt retrieving of alternative language to new DimensionsMenu implementation

### DIFF
--- a/Resources/Private/Templates/TypoScriptObjects/AlternateLanguageLinks.html
+++ b/Resources/Private/Templates/TypoScriptObjects/AlternateLanguageLinks.html
@@ -1,4 +1,4 @@
 {namespace neos=TYPO3\Neos\ViewHelpers}
 {namespace ts=TYPO3\TypoScript\ViewHelpers}
 <f:for each="{items}" as="item"><f:if condition="{item.node}">
-<link rel="alternate" hreflang="{ts:render(path: 'localeToLanguage', context: {item: item})}" href="{neos:uri.node(node : item.node, absolute: true)}"/></f:if></f:for>
+<link rel="alternate" hreflang="{ts:render(path: 'localeToLanguage', context: {item: item, dimension: dimension})}" href="{neos:uri.node(node : item.node, absolute: true)}"/></f:if></f:for>

--- a/Resources/Private/TypoScript/Root.ts2
+++ b/Resources/Private/TypoScript/Root.ts2
@@ -68,7 +68,7 @@ prototype(TYPO3.Neos:Page) {
 			@if.languageDimensionExists = ${Configuration.setting('TYPO3.TYPO3CR.contentDimensions.language') != null}
 			@if.onlyRenderWhenInLiveWorkspace = ${node.context.workspace.name == 'live'}
 
-			localeToLanguage = ${String.replace(item.preset.values[0], '_', '-')}
+			localeToLanguage = ${String.replace((item.preset ? item.preset.values[0] : item.dimensions.language[0]), '_', '-')}
 
 			dimension = 'language'
 			templatePath = 'resource://TYPO3.Neos.Seo/Private/Templates/TypoScriptObjects/AlternateLanguageLinks.html'

--- a/Resources/Private/TypoScript/Root.ts2
+++ b/Resources/Private/TypoScript/Root.ts2
@@ -68,7 +68,7 @@ prototype(TYPO3.Neos:Page) {
 			@if.languageDimensionExists = ${Configuration.setting('TYPO3.TYPO3CR.contentDimensions.language') != null}
 			@if.onlyRenderWhenInLiveWorkspace = ${node.context.workspace.name == 'live'}
 
-			localeToLanguage = ${String.replace((item.preset ? item.preset.values[0] : item.dimensions.language[0]), '_', '-')}
+			localeToLanguage = ${String.replace((item.preset ? item.preset.values[0] : item.dimensions[dimension][0]), '_', '-')}
 
 			dimension = 'language'
 			templatePath = 'resource://TYPO3.Neos.Seo/Private/Templates/TypoScriptObjects/AlternateLanguageLinks.html'


### PR DESCRIPTION
Caused by the new implementation of the DimensionsMenu the preset isn't given anymore. So we retrieve the language through the dimensions.
To support this backwards compatible, we have to check if a preset is set, otherwise we have to use the dimensions of the item.