### PR TITLE
FEATURE: Retrieve active language dimension from TYPO3CR settings

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -111,6 +111,9 @@ example the rendered tags for the homepage would be.
 According to the following dimension settings, there would be a lot more tags expected. However only two variants of the
 homepage exists, thus only `en_US` and its fallback `en_UK` are rendered.
 
+In case the dimension that contains the language is not named `language` you have to set the alternative name with the
+property `TYPO3CR.dimensionTypes.language`.
+
 ::
 
   TYPO3CR:
@@ -150,3 +153,5 @@ homepage exists, thus only `en_US` and its fallback `en_UK` are rendered.
             label: 'Latvian'
             values: ['lv']
             uriSegment: 'lv'
+    dimensionTypes:
+      language: 'language'

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -89,11 +89,11 @@ According to the following dimension settings, there would be a lot more tags ex
 homepage exists, thus only `en_US` and its fallback `en_UK` are rendered.
 
 In case the dimension that contains the language is not named `language` you have to set the alternative name with the
-property `TYPO3CR.dimensionTypes.language`.
+property `ContentRepository.dimensionTypes.language`.
 
 ::
 
-  TYPO3CR:
+  ContentRepository:
     contentDimensions:
       'language':
         label: 'Language'

--- a/Resources/Private/Templates/TypoScriptObjects/AlternateLanguageLinks.html
+++ b/Resources/Private/Templates/TypoScriptObjects/AlternateLanguageLinks.html
@@ -1,4 +1,4 @@
 {namespace neos=TYPO3\Neos\ViewHelpers}
 {namespace ts=TYPO3\TypoScript\ViewHelpers}
 <f:for each="{items}" as="item"><f:if condition="{item.node}">
-<link rel="alternate" hreflang="{ts:render(path: 'localeToLanguage', context: {item: item, dimension: dimension})}" href="{neos:uri.node(node : item.node, absolute: true)}"/></f:if></f:for>
+<link rel="alternate" hreflang="{ts:render(path: 'localeToLanguage', context: {item: item})}" href="{neos:uri.node(node : item.node, absolute: true)}"/></f:if></f:for>

--- a/Resources/Private/TypoScript/Root.ts2
+++ b/Resources/Private/TypoScript/Root.ts2
@@ -3,10 +3,12 @@
 # so TYPO3.Neos.Seo extends this default object
 #
 prototype(TYPO3.Neos:Page) {
+	@context.languageDimension = ${Configuration.setting('TYPO3.TYPO3CR.dimensionTypes.language') != null ? Configuration.setting('TYPO3.TYPO3CR.dimensionTypes.language') : 'language'}
+
 	htmlTag {
 		attributes {
-			lang = ${String.replace(documentNode.context.dimensions.language[0], '_', '-')}
-			lang.@if.languageDimensionExists = ${Configuration.setting('TYPO3.TYPO3CR.contentDimensions.language') != null}
+			lang = ${String.replace(documentNode.context.dimensions[languageDimension][0], '_', '-')}
+			lang.@if.languageDimensionExists = ${Configuration.setting('TYPO3.TYPO3CR.contentDimensions.' + languageDimension) != null}
 			lang.@if.onlyRenderWhenInLiveWorkspace = ${node.context.workspace.name == 'live'}
 		}
 	}
@@ -65,12 +67,11 @@ prototype(TYPO3.Neos:Page) {
 		}
 
 		alternateLanguageLinks = TYPO3.Neos:DimensionMenu {
-			@if.languageDimensionExists = ${Configuration.setting('TYPO3.TYPO3CR.contentDimensions.language') != null}
+			@if.languageDimensionExists = ${Configuration.setting('TYPO3.TYPO3CR.contentDimensions.' + languageDimension) != null}
 			@if.onlyRenderWhenInLiveWorkspace = ${node.context.workspace.name == 'live'}
 
-			localeToLanguage = ${String.replace((item.preset ? item.preset.values[0] : item.dimensions[dimension][0]), '_', '-')}
+			localeToLanguage = ${String.replace((item.preset ? item.preset.values[0] : item.dimensions[languageDimension][0]), '_', '-')}
 
-			dimension = 'language'
 			templatePath = 'resource://TYPO3.Neos.Seo/Private/Templates/TypoScriptObjects/AlternateLanguageLinks.html'
 		}
 

--- a/Resources/Private/TypoScript/Root.ts2
+++ b/Resources/Private/TypoScript/Root.ts2
@@ -72,6 +72,7 @@ prototype(TYPO3.Neos:Page) {
 
 			localeToLanguage = ${String.replace((item.preset ? item.preset.values[0] : item.dimensions[languageDimension][0]), '_', '-')}
 
+			dimension = ${languageDimension}
 			templatePath = 'resource://TYPO3.Neos.Seo/Private/Templates/TypoScriptObjects/AlternateLanguageLinks.html'
 		}
 


### PR DESCRIPTION
Use the TYPO3CR settings to retrieve the current language dimension within the SEO plugin. 
Example:

```
 TYPO3CR:
    languageDimension: 'language'
    contentDimensions:
      'language':
        label: 'Neos.Demo:Main:contentDimensions.language'
        icon: 'icon-language'
        ...
```

The fallback will be `language` so this is non breaking.
