### PR TITLE
TASK: Add translations for placeholders

### DIFF
--- a/Resources/Private/Translations/en/NodeTypes/CanonicalLinkMixin.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/CanonicalLinkMixin.xlf
@@ -8,6 +8,9 @@
 			<trans-unit id="properties.canonicalLink" xml:space="preserve">
 				<source>Canonical Link</source>
 			</trans-unit>
+			<trans-unit id="properties.canonicalLink.textFieldEditor.placeholder" xml:space="preserve">
+				<source>Paste a url, or use the default.</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Translations/en/NodeTypes/OpenGraphMixin.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/OpenGraphMixin.xlf
@@ -11,8 +11,14 @@
 			<trans-unit id="properties.openGraphTitle" xml:space="preserve">
 				<source>Open Graph title</source>
 			</trans-unit>
+			<trans-unit id="properties.openGraphTitle.textAreaEditor.placeholder" xml:space="preserve">
+				<source>Used as og:title, max. 60 chars</source>
+			</trans-unit>
 			<trans-unit id="properties.openGraphDescription" xml:space="preserve">
 				<source>Open Graph Description</source>
+			</trans-unit>
+			<trans-unit id="properties.openGraphDescription.textAreaEditor.placeholder" xml:space="preserve">
+				<source>max. 200 characters</source>
 			</trans-unit>
 			<trans-unit id="properties.openGraphImage" xml:space="preserve">
 				<source>Open Graph Image</source>

--- a/Resources/Private/Translations/en/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/SeoMetaTagsMixin.xlf
@@ -8,7 +8,7 @@
 			<trans-unit id="properties.metaDescription" xml:space="preserve">
 				<source>Description</source>
 			</trans-unit>
-      		<trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
+			<trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
 				<source>max. 156 characters</source>
 			</trans-unit>
 			<trans-unit id="properties.metaKeywords" xml:space="preserve">

--- a/Resources/Private/Translations/en/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/SeoMetaTagsMixin.xlf
@@ -8,8 +8,14 @@
 			<trans-unit id="properties.metaDescription" xml:space="preserve">
 				<source>Description</source>
 			</trans-unit>
+      		<trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
+				<source>max. 156 characters</source>
+			</trans-unit>
 			<trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
+			</trans-unit>
+			<trans-unit id="properties.metaKeywords.textAreaEditor.placeholder" xml:space="preserve">
+				<source>comma separated, max. 255 chars</source>
 			</trans-unit>
 			<trans-unit id="properties.metaRobotsNoindex" xml:space="preserve">
 				<source>Hide from search engines (noindex)</source>

--- a/Resources/Private/Translations/en/NodeTypes/TitleTagMixin.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/TitleTagMixin.xlf
@@ -5,6 +5,9 @@
 			<trans-unit id="properties.titleOverride" xml:space="preserve">
 				<source>Title Override</source>
 			</trans-unit>
+			<trans-unit id="properties.titleOverride.textFieldEditor.placeholder" xml:space="preserve">
+				<source>Used in &lt;title&gt; tag, max. 60 chars</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Translations/en/NodeTypes/TwitterCardMixin.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/TwitterCardMixin.xlf
@@ -11,11 +11,20 @@
 			<trans-unit id="properties.twitterCardCreator" xml:space="preserve">
 				<source>Creator Handle</source>
 			</trans-unit>
+			<trans-unit id="properties.twitterCardCreator.textFieldEditor.placeholder" xml:space="preserve">
+				<source>@johnexample</source>
+			</trans-unit>
 			<trans-unit id="properties.twitterCardTitle" xml:space="preserve">
 				<source>Title</source>
 			</trans-unit>
+			<trans-unit id="properties.twitterCardTitle.textAreaEditor.placeholder" xml:space="preserve">
+				<source>max. 70 characters</source>
+			</trans-unit>
 			<trans-unit id="properties.twitterCardDescription" xml:space="preserve">
 				<source>Description</source>
+			</trans-unit>
+			<trans-unit id="properties.twitterCardDescription.textAreaEditor.placeholder" xml:space="preserve">
+				<source>max. 200 characters</source>
 			</trans-unit>
 			<trans-unit id="properties.twitterCardImage" xml:space="preserve">
 				<source>Card Image</source>

--- a/Resources/Private/Translations/en/NodeTypes/XmlSitemapMixin.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/XmlSitemapMixin.xlf
@@ -11,6 +11,9 @@
 			<trans-unit id="properties.xmlSitemapPriority" xml:space="preserve">
 				<source>Priority</source>
 			</trans-unit>
+			<trans-unit id="properties.xmlSitemapPriority.textFieldEditor.placeholder" xml:space="preserve">
+				<source>between 0 and 1</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>


### PR DESCRIPTION
This change adds translations for all editor placeholders to XLIFF files.

instead of #13
