### PR TITLE
BUGFIX: Improve regular expression validation for Twitter card creator

### DIFF
--- a/Configuration/NodeTypes.Mixins.yaml
+++ b/Configuration/NodeTypes.Mixins.yaml
@@ -116,7 +116,7 @@
             placeholder: '@johnexample'
       validation:
         'Neos.Neos/Validation/RegularExpressionValidator':
-          regularExpression: '/@[a-z0-9_]{1,15}/i'
+          regularExpression: '/^@[a-z0-9_]{1,15}$/i'
     twitterCardTitle:
       type: string
       ui:


### PR DESCRIPTION
Let the regular expression used for Twitter card creator field validation respect the end and start of the string.