### PR TITLE
BUGFIX: Exclude shortcuts from XML sitemap

### DIFF
--- a/Resources/Private/Templates/Page/XmlSiteMap.xml
+++ b/Resources/Private/Templates/Page/XmlSiteMap.xml
@@ -6,6 +6,7 @@
 </urlset>
 <f:section name="itemsList">
 	<f:for each="{items}" as="item">
+		<f:if condition="{item.node.nodeType.name} != 'TYPO3.Neos:Shortcut'">
 		<f:if condition="{item.node.properties.metaRobotsNoindex} == 0">
 			<url>
 				<loc>{neos:uri.node(node: item.node, format: 'html', absolute: true)}</loc>
@@ -13,6 +14,7 @@
 				<f:if condition="{item.node.properties.xmlSitemapChangeFrequency}"><changefreq>{item.node.properties.xmlSitemapChangeFrequency}</changefreq></f:if>
 				<priority>{f:if(condition: item.node.properties.xmlSitemapPriority, then: item.node.properties.xmlSitemapPriority, else: '0.5')}</priority>
 			</url>
+		</f:if>
 		</f:if>
 		<f:if condition="{item.subItems}"><f:render section="itemsList" arguments="{items: item.subItems}"/></f:if>
 	</f:for>


### PR DESCRIPTION
When shortcuts are included in the XML sitemap, that may lead to
invalid sitemap entries: If a shortcut points to an external URL,
it violates the XML sitemap protocol.