### PR TITLE
Renamed twitter card image meta tag

### DIFF
--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -125,7 +125,7 @@ prototype(Neos.Neos:Page) {
 			cardImageTag = Neos.Fusion:Tag {
 				tagName = 'meta'
 				attributes {
-					name = 'twitter:image:src'
+					name = 'twitter:image'
 					content = Neos.Neos:ImageUri {
 						asset = ${q(node).property('twitterCardImage')}
 						maximumWidth = 2000


### PR DESCRIPTION
Twitter changed the name form twitter:image:src to twitter:image:
https://dev.twitter.com/cards/markup