### PR TITLE
TASK: Change null-keys in YAML to empty strings

### DIFF
--- a/Configuration/NodeTypes.Mixins.yaml
+++ b/Configuration/NodeTypes.Mixins.yaml
@@ -90,16 +90,15 @@
   properties:
     twitterCardType:
       type: string
-      defaultValue: ''
       ui:
         label: i18n
         inspector:
           group: 'twittercard'
           editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
           editorOptions:
+            allowEmpty: true
+            placeholder: 'None'
             values:
-              '':
-                label: 'None'
               'summary':
                 label: 'Summary Card'
               'summary_large_image':
@@ -192,16 +191,15 @@
   properties:
     openGraphType:
       type: string
-      defaultValue: ''
       ui:
         label: i18n
         inspector:
           group: 'openGraph'
           editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
           editorOptions:
+            allowEmpty: true
+            placeholder: 'None'
             values:
-              '':
-                label: 'None'
               'website':
                 label: 'Website'
               'article':
@@ -257,7 +255,6 @@
   properties:
     xmlSitemapChangeFrequency:
       type: string
-      defaultValue: ''
       ui:
         label: i18n
         inspector:
@@ -265,9 +262,9 @@
           position: 10
           editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
           editorOptions:
+            allowEmpty: true
+            placeholder: 'none (unspecified)'
             values:
-              '':
-                label: 'none (unspecified)'
               'always':
                 label: 'Always'
               'hourly':

--- a/Configuration/NodeTypes.Mixins.yaml
+++ b/Configuration/NodeTypes.Mixins.yaml
@@ -90,7 +90,7 @@
   properties:
     twitterCardType:
       type: string
-      defaultValue: ~
+      defaultValue: ''
       ui:
         label: i18n
         inspector:
@@ -98,7 +98,7 @@
           editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
           editorOptions:
             values:
-              ~:
+              '':
                 label: 'None'
               'summary':
                 label: 'Summary Card'
@@ -192,7 +192,7 @@
   properties:
     openGraphType:
       type: string
-      defaultValue: ~
+      defaultValue: ''
       ui:
         label: i18n
         inspector:
@@ -200,7 +200,7 @@
           editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
           editorOptions:
             values:
-              ~:
+              '':
                 label: 'None'
               'website':
                 label: 'Website'
@@ -257,6 +257,7 @@
   properties:
     xmlSitemapChangeFrequency:
       type: string
+      defaultValue: ''
       ui:
         label: i18n
         inspector:
@@ -265,7 +266,7 @@
           editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
           editorOptions:
             values:
-              ~:
+              '':
                 label: 'none (unspecified)'
               'always':
                 label: 'Always'


### PR DESCRIPTION
Tilde as key is not allowed in yaml and rejected by the updated
YAML parser. This changes the values to empty string values.

Note: Quoting would remove error messages during parsing, but
the result is not an empty string (as with the older parser), but literally the string `~`.