### PR TITLE
BUGFIX: unset titleTag before assigning Neos.Seo:TitleTag

### DIFF
--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -3,6 +3,7 @@ include: Prototypes/*.fusion
 prototype(Neos.Neos:Page) {
     htmlTag.attributes.lang = Neos.Seo:LangAttribute
     head {
+        titleTag >
         titleTag = Neos.Seo:TitleTag
         metaDescriptionTag = Neos.Seo:MetaDescriptionTag
         metaKeywordsTag = Neos.Seo:MetaKeywordsTag


### PR DESCRIPTION
Hello,

I don't really understand why it doesn't work here...

If I don't reset the titleTag, the Neos.Seo version is not working (titleOverride is not used at all).
But as I understand, it should work as there is a simple "merge" done here.

I would be blessed by a small explanation here 👍.

Tested with Neos 3.3.9