### PR TITLE
TASK: Hide canonical-tag if metaRobotsNoindex is enabled

### DIFF
--- a/Resources/Private/Fusion/Prototypes/CanonicalLink.fusion
+++ b/Resources/Private/Fusion/Prototypes/CanonicalLink.fusion
@@ -8,4 +8,5 @@ prototype(Neos.Seo:CanonicalLink) < prototype(Neos.Fusion:Tag) {
         }
         href.@process.canonical = ${q(node).property('canonicalLink') ? q(node).property('canonicalLink') : value}
     }
+    @if.hideIfNoIndexIsSet = ${q(node).property('metaRobotsNoindex') ? false : true}
 }


### PR DESCRIPTION
Canonical-tags on documents with no-index make no sense but actually may be harmful.
This change hides the canonical-tag for documents that have metaRobotsNoindex enabled.

See: 
- https://www.seroundtable.com/google-canonical-noindex-24288.html
- https://www.seroundtable.com/noindex-canonical-google-18274.html