### PR TITLE
TASK: Hide hreflang links if canonical is set and show default link

### DIFF
--- a/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.fusion
+++ b/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.fusion
@@ -1,6 +1,7 @@
 prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Neos:DimensionMenu) {
     @if.languageDimensionExists = ${Configuration.setting('Neos.ContentRepository.contentDimensions.language') != null}
     @if.onlyRenderWhenInLiveWorkspace = ${node.context.workspace.name == 'live'}
+    @if.hasNoForeignCanonical = ${String.isBlank(q(node).property('canonicalLink'))}
 
     localeToLanguage = ${String.replace((item.preset ? item.preset.values[0] : item.dimensions[dimension][0]), '_', '-')}
 

--- a/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.fusion
+++ b/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.fusion
@@ -1,4 +1,4 @@
-prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Neos:DimensionMenu) {
+prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Neos:DimensionsMenu) {
     @if.languageDimensionExists = ${Configuration.setting('Neos.ContentRepository.contentDimensions.language') != null}
     @if.onlyRenderWhenInLiveWorkspace = ${node.context.workspace.name == 'live'}
     @if.hasNoForeignCanonical = ${String.isBlank(q(node).property('canonicalLink'))}

--- a/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.fusion
+++ b/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.fusion
@@ -3,6 +3,7 @@ prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Neos:DimensionsMenu)
     @if.onlyRenderWhenInLiveWorkspace = ${node.context.workspace.name == 'live'}
     @if.hasNoForeignCanonical = ${String.isBlank(q(node).property('canonicalLink'))}
 
+    defaultLocale = ${Configuration.setting('Neos.ContentRepository.contentDimensions.language.default')}
     localeToLanguage = ${String.replace((item.preset ? item.preset.values[0] : item.dimensions[dimension][0]), '_', '-')}
 
     dimension = 'language'

--- a/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.html
+++ b/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.html
@@ -1,4 +1,5 @@
 {namespace neos=Neos\Neos\ViewHelpers}
 {namespace ts=Neos\Fusion\ViewHelpers}
 <f:for each="{items}" as="item"><f:if condition="{item.node}">
+<f:if condition="{defaultLocale} == {item.dimensions.language.0}"><link rel="alternate" hreflang="x-default" href="{neos:uri.node(node : item.node, absolute: true)}"/></f:if>
 <link rel="alternate" hreflang="{ts:render(path: 'localeToLanguage', context: {item: item, dimension: dimension})}" href="{neos:uri.node(node : item.node, absolute: true)}"/></f:if></f:for>


### PR DESCRIPTION
If editor sets a canonical url manually it normally leads
to another url, therefore hreflang links confuse
search engines as the page anyway has no „own“
content by definition.

Also renders x-default link.

Resolves: #43