### PR TITLE
TASK: Render sitemap with fusion

### DIFF
--- a/Resources/Private/Fusion/Prototypes/XmlSiteMap.xml
+++ b/Resources/Private/Fusion/Prototypes/XmlSiteMap.xml
@@ -1,21 +1,2 @@
-{namespace neos=Neos\Neos\ViewHelpers}
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    <url>
-        <loc>{neos:uri.node(node: root, format: 'html', absolute: true)}</loc><lastmod>{root.lastModificationDateTime -> f:format.date(format: 'Y-m-d\TH:iP')}</lastmod><f:if condition="{root.sitemapXmlChangeFrequency}"><changefreq>{root.sitemapXmlChangeFrequency}</changefreq></f:if><f:if condition="{root.sitemapXmlPriority}"><priority>{root.sitemapXmlPriority}</priority></f:if>
-    </url><f:render section="itemsList" arguments="{items: items}" />
-</urlset>
-<f:section name="itemsList">
-    <f:for each="{items}" as="item">
-        <f:if condition="{item.node.nodeType.name} != 'Neos.Neos:Shortcut'">
-        <f:if condition="{item.node.properties.metaRobotsNoindex} == 0">
-            <url>
-                <loc>{neos:uri.node(node: item.node, format: 'html', absolute: true)}</loc>
-                <lastmod>{item.node.lastModificationDateTime -> f:format.date(format: 'Y-m-d\TH:iP')}</lastmod>
-                <f:if condition="{item.node.properties.xmlSitemapChangeFrequency}"><changefreq>{item.node.properties.xmlSitemapChangeFrequency}</changefreq></f:if>
-                <priority>{f:if(condition: item.node.properties.xmlSitemapPriority, then: item.node.properties.xmlSitemapPriority, else: '0.5')}</priority>
-            </url>
-        </f:if>
-        </f:if>
-        <f:if condition="{item.subItems}"><f:render section="itemsList" arguments="{items: item.subItems}"/></f:if>
-    </f:for>
-</f:section>
+{namespace fusion=Neos\Fusion\ViewHelpers}
+<fusion:render path="urlset" />

--- a/Resources/Private/Fusion/Prototypes/XmlSitemap.fusion
+++ b/Resources/Private/Fusion/Prototypes/XmlSitemap.fusion
@@ -3,14 +3,28 @@ prototype(Neos.Seo:XmlSitemap) < prototype(Neos.Fusion:Http.Message) {
     httpResponseHead.headers.Content-Type = 'text/xml'
 
     body = Neos.Neos:Menu {
-        root = ${site}
         entryLevel = 0
         maximumLevels = 999
-        renderHiddenInIndex = TRUE
+        renderHiddenInIndex = true
         templatePath = 'resource://Neos.Seo/Private/Fusion/Prototypes/XmlSiteMap.xml'
         startingPoint = ${site}
 
-        @cache.entryTags.1 = ${'DescendantOf_' + this.startingPoint.identifier}
+        @context {
+            startingPoint = ${this.startingPoint}
+            items = ${this.items}
+        }
+
+        urlset = afx`
+            <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                <Neos.Seo:XmlSitemap.Url node={startingPoint}/>
+                <Neos.Seo:XmlSitemap.UrlList items={items} @if.hasItems={items}/>
+            </urlset>
+        `
+
+        @cache.entryTags {
+            1 = ${Neos.Caching.nodeTag(this.startingPoint)}
+            2 = ${Neos.Caching.descendantOfTag(this.startingPoint)}
+        }
     }
 }
 

--- a/Resources/Private/Fusion/Prototypes/XmlSitemapUrl.fusion
+++ b/Resources/Private/Fusion/Prototypes/XmlSitemapUrl.fusion
@@ -1,0 +1,18 @@
+prototype(Neos.Seo:XmlSitemap.Url) < prototype(Neos.Fusion:Component) {
+    node = null
+    lastModificationDateTime = ${Date.format(this.node.lastModificationDateTime, 'Y-m-d\TH:iP')}
+    changeFrequency = ${q(this.node).property('xmlSitemapChangeFrequency')}
+    priority = ${q(this.node).property('xmlSitemapPriority') || 0.5}
+
+    @if.isNotShortcut = ${!q(this.node).is('[instanceof Neos.Neos:Shortcut]')}
+    @if.indexable = ${!q(this.node).property('metaRobotsNoindex')}
+
+    renderer = afx`
+        <url>
+            <loc @key="loc"><Neos.Neos:NodeUri node={props.node} format="html" absolute={true}/></loc>
+            <lastmod @key="lastmod">{props.lastModificationDateTime}</lastmod>
+            <changefreq @key="changefreq" @if.hasChangeFrequency={props.changeFrequency}>{props.changeFrequency}</changefreq>
+            <priority @key="priority" @if.hasPriority={props.priority}>{props.priority}</priority>
+        </url>
+    `
+}

--- a/Resources/Private/Fusion/Prototypes/XmlSitemapUrlList.fusion
+++ b/Resources/Private/Fusion/Prototypes/XmlSitemapUrlList.fusion
@@ -1,0 +1,10 @@
+prototype(Neos.Seo:XmlSitemap.UrlList) < prototype(Neos.Fusion:Component) {
+    items = ${[]}
+
+    renderer = afx`
+        <Neos.Fusion:Collection collection={props.items} itemName="item" @children="itemRenderer">
+            <Neos.Seo:XmlSitemap.Url node={item.node}/>
+            <Neos.Seo:XmlSitemap.UrlList items={item.subItems} @if.hasSubItems={item.subItems}/>
+        </Neos.Fusion:Collection>
+    `
+}

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "description": "SEO configuration and tools for Neos",
     "license": "GPL-3.0-or-later",
     "require": {
-        "neos/neos": "~3.0 || ~4.0 || dev-master"
+        "neos/neos": "~3.2 || ~4.0 || dev-master",
+        "neos/fusion-afx": "~1.0 || dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This change is not breaking and will render the xml sitemap with afx-fusion instead of fluid.
This allows easier overriding and extending of the sitemap for future extensions like alternate language links.

This change also fixes the following existing issues:

* Sitemap was not refreshed when updating homepage
* Change frequency and priority of homepage were not rendered
* Reduced performance because of use of node.properties
* Nodetypes inheriting from Neos.Neos:Shortcut were rendered