### PR TITLE
TASK: Hreflang rendering with fusion

### DIFF
--- a/Resources/Private/Fusion/Prototypes/AlternateLanguageLink.fusion
+++ b/Resources/Private/Fusion/Prototypes/AlternateLanguageLink.fusion
@@ -1,0 +1,16 @@
+prototype(Neos.Seo:AlternateLanguageLink) < prototype(Neos.Fusion:Component) {
+    node = null
+    hreflang = ''
+
+    // Define current node as the documentNode so dimension uri is resolved correctly
+    @context.documentNode = ${this.node}
+
+    nodeUri = Neos.Neos:NodeUri {
+        node = ${props.node}
+        absolute = true
+    }
+
+    renderer = afx`<link rel="alternate" hreflang={props.hreflang} href={props.nodeUri}/>`
+
+    @if.hasNode = ${this.node}
+}

--- a/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.fusion
+++ b/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.fusion
@@ -1,6 +1,7 @@
 prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Neos:DimensionMenu) {
     @if.languageDimensionExists = ${Configuration.setting('Neos.ContentRepository.contentDimensions.language') != null}
     @if.onlyRenderWhenInLiveWorkspace = ${node.context.workspace.name == 'live'}
+    @if.hasNoForeignCanonical = ${String.isBlank(q(node).property('canonicalLink'))}
 
     localeToLanguage = ${String.replace((item.preset ? item.preset.values[0] : item.dimensions[dimension][0]), '_', '-')}
 

--- a/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.fusion
+++ b/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.fusion
@@ -4,8 +4,20 @@ prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Neos:DimensionsMenu)
     @if.hasNoForeignCanonical = ${String.isBlank(q(node).property('canonicalLink'))}
 
     defaultLocale = ${Configuration.setting('Neos.ContentRepository.contentDimensions.language.default')}
-    localeToLanguage = ${String.replace((item.preset ? item.preset.values[0] : item.dimensions[dimension][0]), '_', '-')}
 
     dimension = 'language'
     templatePath = 'resource://Neos.Seo/Private/Fusion/Prototypes/AlternateLanguageLinks.html'
+
+    @context {
+        items = ${this.items}
+        defaultLocale = ${this.defaultLocale}
+        dimension = ${this.dimension}
+    }
+
+    links = afx`
+        <Neos.Fusion:Collection collection={items} itemName="item" @children="itemRenderer">
+            <Neos.Seo:AlternateLanguageLink node={item.node} hreflang="x-default" @if.isDefaultLocale={defaultLocale == item.dimensions[dimension][0]}/>
+            <Neos.Seo:AlternateLanguageLink node={item.node} hreflang={String.replace((item.preset ? item.preset.values[0] : item.dimensions[dimension][0]), '_', '-')}/>
+        </Neos.Fusion:Collection>
+    `
 }

--- a/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.fusion
+++ b/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.fusion
@@ -1,4 +1,4 @@
-prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Neos:DimensionMenu) {
+prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Neos:DimensionsMenu) {
     @if.languageDimensionExists = ${Configuration.setting('Neos.ContentRepository.contentDimensions.language') != null}
     @if.onlyRenderWhenInLiveWorkspace = ${node.context.workspace.name == 'live'}
     @if.hasNoForeignCanonical = ${String.isBlank(q(node).property('canonicalLink'))}

--- a/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.fusion
+++ b/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.fusion
@@ -3,6 +3,7 @@ prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Neos:DimensionsMenu)
     @if.onlyRenderWhenInLiveWorkspace = ${node.context.workspace.name == 'live'}
     @if.hasNoForeignCanonical = ${String.isBlank(q(node).property('canonicalLink'))}
 
+    defaultLocale = ${Configuration.setting('Neos.ContentRepository.contentDimensions.language.default')}
     localeToLanguage = ${String.replace((item.preset ? item.preset.values[0] : item.dimensions[dimension][0]), '_', '-')}
 
     dimension = 'language'

--- a/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.html
+++ b/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.html
@@ -1,4 +1,5 @@
 {namespace neos=Neos\Neos\ViewHelpers}
 {namespace ts=Neos\Fusion\ViewHelpers}
 <f:for each="{items}" as="item"><f:if condition="{item.node}">
+<f:if condition="{defaultLocale} == {item.dimensions.language.0}"><link rel="alternate" hreflang="x-default" href="{neos:uri.node(node : item.node, absolute: true)}"/></f:if>
 <link rel="alternate" hreflang="{ts:render(path: 'localeToLanguage', context: {item: item, dimension: dimension})}" href="{neos:uri.node(node : item.node, absolute: true)}"/></f:if></f:for>

--- a/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.html
+++ b/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.html
@@ -1,5 +1,2 @@
-{namespace neos=Neos\Neos\ViewHelpers}
-{namespace ts=Neos\Fusion\ViewHelpers}
-<f:for each="{items}" as="item"><f:if condition="{item.node}">
-<f:if condition="{defaultLocale} == {item.dimensions.language.0}"><link rel="alternate" hreflang="x-default" href="{neos:uri.node(node : item.node, absolute: true)}"/></f:if>
-<link rel="alternate" hreflang="{ts:render(path: 'localeToLanguage', context: {item: item, dimension: dimension})}" href="{neos:uri.node(node : item.node, absolute: true)}"/></f:if></f:for>
+{namespace fusion=Neos\Fusion\ViewHelpers}
+<fusion:render path="links"/>


### PR DESCRIPTION
Convert rendering of hreflang links to fusion.
This way they can be extended and also be used in a sitemap or other place.

This change requires #59 and #61 to be merged first and should not be breaking.

Resolves: #60 