### PR TITLE
FEATURE: Optional output of alternate language links in sitemap

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -112,6 +112,12 @@ By default all shortcuts are ignored in the sitemap. They inherit from the proto
 If you have other document types that should not appear in the sitemap you can also let them inherit from
 that prototype.
 
+To include alternate language links of pages in the xml sitemap use the following fusion code::
+
+    prototype(Neos.Seo:XmlSitemap) {
+        body.includeAlternateLanguageLinks = true
+    }
+
 Alternate Language Tag
 ------------------------
 

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -118,6 +118,10 @@ To include alternate language links of pages in the xml sitemap use the followin
         body.includeAlternateLanguageLinks = true
     }
 
+Be aware of possible performance issues. Rendering the sitemap with all optional features might be slow
+for larger installations and needs an optimized `XmlSitemapImplementation` which could use ElasticSearch for example.
+Alternatively you can change the caching behavior and have a cron job that recreates the sitemap for example once per day.
+
 Alternate Language Tag
 ------------------------
 

--- a/Resources/Private/Fusion/Prototypes/AlternateLanguageLink.fusion
+++ b/Resources/Private/Fusion/Prototypes/AlternateLanguageLink.fusion
@@ -3,10 +3,14 @@ prototype(Neos.Seo:AlternateLanguageLink) < prototype(Neos.Fusion:Component) {
     hreflang = ''
 
     // Define current node as the documentNode so dimension uri is resolved correctly
-    @context.documentNode = ${this.node}
+    @context {
+        node = ${this.node}
+        documentNode = ${this.node}
+    }
 
     nodeUri = Neos.Neos:NodeUri {
-        node = ${props.node}
+        format = 'html'
+        node = ${node}
         absolute = true
     }
 

--- a/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.fusion
+++ b/Resources/Private/Fusion/Prototypes/AlternateLanguageLinks.fusion
@@ -1,12 +1,12 @@
 prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Neos:DimensionsMenu) {
     @if.languageDimensionExists = ${this.dimensionConfiguration != null}
-    @if.onlyRenderWhenInLiveWorkspace = ${node.context.workspace.name == 'live'}
-    @if.hasNoForeignCanonical = ${String.isBlank(q(node).property('canonicalLink'))}
+    @if.onlyRenderWhenInLiveWorkspace = ${this.node.context.workspace.name == 'live'}
+    @if.hasNoForeignCanonical = ${String.isBlank(q(this.node).property('canonicalLink'))}
 
+    node = null
     dimension = 'language'
     defaultLocale = ${Configuration.setting('Neos.ContentRepository.contentDimensions.' + this.dimension + '.default')}
     dimensionConfiguration = ${Configuration.setting('Neos.ContentRepository.contentDimensions.' + this.dimension)}
-
     templatePath = 'resource://Neos.Seo/Private/Fusion/Prototypes/AlternateLanguageLinks.html'
 
     @context {
@@ -18,7 +18,7 @@ prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Neos:DimensionsMenu)
 
     links = afx`
         <Neos.Fusion:Collection collection={items} itemName="item" @children="itemRenderer">
-            <Neos.Seo:AlternateLanguageLink node={item.node} hreflang="x-default" @if.isDefaultLocale={defaultLocale == item.dimensions[dimension][0]}/>
+            <Neos.Seo:AlternateLanguageLink @key="defaultLink" node={item.node} hreflang="x-default" @if.isDefaultLocale={defaultLocale == item.dimensions[dimension][0]}/>
             <Neos.Seo:AlternateLanguageLink node={item.node} hreflang={String.replace((item.preset ? item.preset.values[0] : item.dimensions[dimension][0]), '_', '-')}/>
         </Neos.Fusion:Collection>
     `

--- a/Resources/Private/Fusion/Prototypes/XmlSitemap.fusion
+++ b/Resources/Private/Fusion/Prototypes/XmlSitemap.fusion
@@ -20,7 +20,7 @@ prototype(Neos.Seo:XmlSitemap) < prototype(Neos.Fusion:Http.Message) {
         urlset = afx`
             <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
                     xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
-                    xmlns:xhtml="http://www.w3.org/1999/xhtml">
+                    xmlns:xhtml="http://www.w3.org/1999/xhtml/">
                 <Neos.Seo:XmlSitemap.UrlList items={items} includeAlternateLanguageLinks={includeAlternateLanguageLinks} @if.hasItems={items}/>
             </urlset>
         `

--- a/Resources/Private/Fusion/Prototypes/XmlSitemap.fusion
+++ b/Resources/Private/Fusion/Prototypes/XmlSitemap.fusion
@@ -9,14 +9,19 @@ prototype(Neos.Seo:XmlSitemap) < prototype(Neos.Fusion:Http.Message) {
         root = ${site}
         startingPoint = ${site}
         includeImageUrls = false
+        includeAlternateLanguageLinks = false
         renderHiddenInIndex = true
 
-        @context.items = ${this.items}
+        @context {
+            items = ${this.items}
+            includeAlternateLanguageLinks = ${this.includeAlternateLanguageLinks}
+        }
 
         urlset = afx`
             <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-                    xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
-                <Neos.Seo:XmlSitemap.UrlList items={items} @if.hasItems={items}/>
+                    xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+                    xmlns:xhtml="http://www.w3.org/1999/xhtml">
+                <Neos.Seo:XmlSitemap.UrlList items={items} includeAlternateLanguageLinks={includeAlternateLanguageLinks} @if.hasItems={items}/>
             </urlset>
         `
 

--- a/Resources/Private/Fusion/Prototypes/XmlSitemapUrl.fusion
+++ b/Resources/Private/Fusion/Prototypes/XmlSitemapUrl.fusion
@@ -5,6 +5,17 @@ prototype(Neos.Seo:XmlSitemap.Url) < prototype(Neos.Fusion:Component) {
     changeFrequency = ''
     priority = ''
     images = ${[]}
+    includeAlternateLanguageLinks = false
+
+    prototype(Neos.Seo:AlternateLanguageLinks) {
+        links.itemRenderer.defaultLink >
+    }
+
+    prototype(Neos.Seo:AlternateLanguageLink) {
+        renderer.tagName = 'xhtml:link'
+    }
+
+    @context.documentNode = ${this.node}
 
     renderer = afx`
         <url>
@@ -13,6 +24,7 @@ prototype(Neos.Seo:XmlSitemap.Url) < prototype(Neos.Fusion:Component) {
             <changefreq @key="changefreq" @if.hasChangeFrequency={props.changeFrequency}>{props.changeFrequency}</changefreq>
             <priority @key="priority" @if.hasPriority={props.priority}>{props.priority}</priority>
             <Neos.Seo:XmlSitemap.ImageUrls @key="images" images={props.images} @if.hasImages={props.images}/>
+            <Neos.Seo:AlternateLanguageLinks @key="alternateLanguageLinks" node={props.node} @if.includeAlternateLanguageLinks={props.includeAlternateLanguageLinks}/>
         </url>
     `
 }

--- a/Resources/Private/Fusion/Prototypes/XmlSitemapUrlList.fusion
+++ b/Resources/Private/Fusion/Prototypes/XmlSitemapUrlList.fusion
@@ -1,9 +1,11 @@
 prototype(Neos.Seo:XmlSitemap.UrlList) < prototype(Neos.Fusion:Component) {
     items = ${[]}
+    includeAlternateLanguageLinks = false
 
     renderer = afx`
         <Neos.Fusion:Collection collection={props.items} itemName="item" @children="itemRenderer">
             <Neos.Seo:XmlSitemap.Url node={item.node} lastModificationDateTime={item.lastModificationDateTime}
+                                     includeAlternateLanguageLinks={props.includeAlternateLanguageLinks}
                                      priority={item.priority} changeFrequency={item.changeFrequency} images={item.images}/>
         </Neos.Fusion:Collection>
     `


### PR DESCRIPTION
This change allows to render alternate language links
in the xml sitemap.
This is not active by default because of possible
performance issues with big sites.