### PR TITLE
TASK: Remove default value for priority tag

### DIFF
--- a/Resources/Private/Fusion/Prototypes/XmlSitemapUrl.fusion
+++ b/Resources/Private/Fusion/Prototypes/XmlSitemapUrl.fusion
@@ -3,7 +3,7 @@ prototype(Neos.Seo:XmlSitemap.Url) < prototype(Neos.Fusion:Component) {
     lastModificationDateTime = ${Date.now()}
     lastModificationDateTime.@process.format = ${Date.format(value, 'Y-m-d\TH:iP')}
     changeFrequency = ''
-    priority = '0.5'
+    priority = ''
     images = ${[]}
 
     renderer = afx`


### PR DESCRIPTION
Search engines use 0.5 as default, so there is no need to give this value