### PR TITLE
FEATURE: Optional output of the site owners social profile as structured data

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -22,3 +22,12 @@ Neos:
     twitterCard:
       # the Twitter handle for the twitter:site attribution
       siteHandle: ~
+
+    # Social profile names for the structured data object
+    socialProfiles:
+      twitter: ~
+      facebook: ~
+      instagram: ~
+      linkedIn: ~
+      youTube: ~
+

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -23,11 +23,16 @@ Neos:
       # the Twitter handle for the twitter:site attribution
       siteHandle: ~
 
-    # Social profile names for the structured data object
-    socialProfiles:
-      twitter: ~
-      facebook: ~
-      instagram: ~
-      linkedIn: ~
-      youTube: ~
+    # Social profile for the structured data object
+    socialProfile:
+      # `type` can be either `Person` or `Organization`
+      type: Person
+      # `logo` can be for example `resource://Vendor.Site/Public/Images/MyLogo.png`
+      logo: ''
+      profiles:
+        twitter: ~
+        facebook: ~
+        instagram: ~
+        linkedIn: ~
+        youTube: ~
 

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -137,6 +137,10 @@ To include contained images of pages in the xml sitemap use the following fusion
         body.includeImageUrls = true
     }
 
+Be aware that the sitemap will output all images referenced in a page and it's content.
+If you reference images that should not render in the frontend you might need to adjust the sitemap according
+to your needs.
+
 By default all shortcuts are ignored in the sitemap. They inherit from the prototype `Neos.Seo:NoindexMixin`.
 If you have other document types that should not appear in the sitemap you can also let them inherit from
 that prototype.

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -90,6 +90,35 @@ You can enable this feature with the following code::
 
     prototype(Neos.Seo:StructuredData.Container).breadcrumb.@if.enabled = true
 
+Social profile
+^^^^^^^^^^^^^^
+
+Search engines can output information about the social profile by passing a structured data
+representation of a documents rootline.
+Depending whether the site is run by a person or organization some parts need to be configured.
+
+More information is available here:
+* https://developers.google.com/search/docs/data-types/social-profile
+* https://developers.google.com/search/docs/data-types/logo
+
+You can enable this feature with the following code::
+
+    prototype(Neos.Seo:StructuredData.Container).socialProfile.@if.enabled = true
+
+To adjust the profile configure this according to your requirements in your `Settings.yaml`::
+
+    Neos:
+      Seo:
+        socialProfile:
+          type: 'set either to "Person" or "Organization"'
+          logo: 'resource://Vendor.Site/Public/Images/MyLogo.png'
+          profiles:
+            twitter: 'your twitter name'
+            facebook: 'your facebook name'
+            instagram: 'your instagram name'
+            linkedIn: 'your linkedin name'
+            youTube: 'your YouTube channel identifier'
+
 XML sitemap
 -----------
 

--- a/Resources/Private/Fusion/Prototypes/StructuredDataContainer.fusion
+++ b/Resources/Private/Fusion/Prototypes/StructuredDataContainer.fusion
@@ -1,4 +1,7 @@
 prototype(Neos.Seo:StructuredData.Container) < prototype(Neos.Fusion:Array) {
     breadcrumb = Neos.Seo:StructuredData.Breadcrumb
     breadcrumb.@if.enabled = false
+
+    socialProfile = Neos.Seo:StructuredData.SocialProfile
+    socialProfile.@if.enabled = false
 }

--- a/Resources/Private/Fusion/Prototypes/StructuredDataSocialProfile.fusion
+++ b/Resources/Private/Fusion/Prototypes/StructuredDataSocialProfile.fusion
@@ -1,0 +1,46 @@
+prototype(Neos.Seo:StructuredData.SocialProfile) < prototype(Neos.Fusion:Component) {
+    @if.onHomepage = ${documentNode == site}
+    @if.hasProfiles = ${Array.length(this.profiles) > 0}
+
+    // 'type' can either be 'Person' or 'Organization' and should be set accordingly
+    type = 'Person'
+    twitterName = ${q(documentNode).property('twitterCardCreator') || Configuration.setting('Neos.Seo.socialProfiles.twitter')}
+    facebookName = ${Configuration.setting('Neos.Seo.socialProfiles.facebook')}
+    instagramName = ${Configuration.setting('Neos.Seo.socialProfiles.instagram')}
+    youTubeName = ${Configuration.setting('Neos.Seo.socialProfiles.youTube')}
+    linkedInName = ${Configuration.setting('Neos.Seo.socialProfiles.linkedIn')}
+
+    @context {
+        twitterName = ${this.twitterName}
+        facebookName = ${this.facebookName}
+        instagramName = ${this.instagramName}
+        youTubeName = ${this.youTubeName}
+        linkedInName = ${this.linkedInName}
+    }
+
+    profiles = Neos.Fusion:RawArray {
+        twitter = ${'https://twitter.com/' + twitterName}
+        twitter.@if.hasValue = ${!String.isBlank(twitterName)}
+
+        facebook = ${'https://www.facebook.com/' + facebookName}
+        facebook.@if.hasValue = ${!String.isBlank(facebookName)}
+
+        instagram = ${'https://www.instagram.com/' + instagramName}
+        instagram.@if.hasValue = ${!String.isBlank(instagramName)}
+
+        youTube = ${'https://www.youtube.com/channel/' + youTubeName}
+        youTube.@if.hasValue = ${!String.isBlank(youTubeName)}
+
+        linkedIn = ${'https://www.linkedin.com/in/' + linkedInName}
+        linkedIn.@if.hasValue = ${!String.isBlank(linkedInName)}
+    }
+
+    renderer = afx`
+        <script type="application/ld+json">
+            <Neos.Seo:StructuredData.RootObject type={props.type} url={siteUrl} profiles={props.profiles} @children="renderer.sameAs">
+                <Neos.Fusion:RawCollection collection={props.profiles} itemName="profile"
+                                           iterationName="iteration" itemRenderer={profile}/>
+            </Neos.Seo:StructuredData.RootObject>
+        </script>
+    `
+}

--- a/Resources/Private/Fusion/Prototypes/StructuredDataSocialProfile.fusion
+++ b/Resources/Private/Fusion/Prototypes/StructuredDataSocialProfile.fusion
@@ -3,14 +3,15 @@ prototype(Neos.Seo:StructuredData.SocialProfile) < prototype(Neos.Fusion:Compone
     @if.hasProfiles = ${Array.length(this.profiles) > 0}
 
     // 'type' can either be 'Person' or 'Organization' and should be set accordingly
-    type = 'Person'
-    twitterName = ${q(documentNode).property('twitterCardCreator') || Configuration.setting('Neos.Seo.socialProfiles.twitter')}
-    facebookName = ${Configuration.setting('Neos.Seo.socialProfiles.facebook')}
-    instagramName = ${Configuration.setting('Neos.Seo.socialProfiles.instagram')}
-    youTubeName = ${Configuration.setting('Neos.Seo.socialProfiles.youTube')}
-    linkedInName = ${Configuration.setting('Neos.Seo.socialProfiles.linkedIn')}
+    type = ${Configuration.setting('Neos.Seo.socialProfile.type')}
+    twitterName = ${q(documentNode).property('twitterCardCreator') || Configuration.setting('Neos.Seo.socialProfile.profiles.twitter')}
+    facebookName = ${Configuration.setting('Neos.Seo.socialProfile.profiles.facebook')}
+    instagramName = ${Configuration.setting('Neos.Seo.socialProfile.profiles.instagram')}
+    youTubeName = ${Configuration.setting('Neos.Seo.socialProfile.profiles.youTube')}
+    linkedInName = ${Configuration.setting('Neos.Seo.socialProfile.profiles.linkedIn')}
 
     @context {
+        type = ${this.type}
         twitterName = ${this.twitterName}
         facebookName = ${this.facebookName}
         instagramName = ${this.instagramName}
@@ -18,6 +19,21 @@ prototype(Neos.Seo:StructuredData.SocialProfile) < prototype(Neos.Fusion:Compone
         linkedInName = ${this.linkedInName}
     }
 
+    // Automatically add site url for organizations, see https://developers.google.com/search/docs/data-types/logo
+    siteUrl = Neos.Neos:NodeUri {
+        node = ${site}
+        absolute = true
+        @if.isOrganization = ${type == 'Organization'}
+    }
+
+    // Allow setting a logo path for organizations, see https://developers.google.com/search/docs/data-types/logo
+    // Example: logo.path = 'resource://Vendor.Site/Public/Images/MyLogo.png'
+    logo = Neos.Fusion:ResourceUri {
+        path = ${Configuration.setting('Neos.Seo.socialProfile.logo')}
+        @if.isOrganization = ${type == 'Organization' && !String.isBlank(this.path)}
+    }
+
+    // Automatically adds social profiles for a site owner, see https://developers.google.com/search/docs/data-types/social-profile
     profiles = Neos.Fusion:RawArray {
         twitter = ${'https://twitter.com/' + twitterName}
         twitter.@if.hasValue = ${!String.isBlank(twitterName)}
@@ -37,7 +53,8 @@ prototype(Neos.Seo:StructuredData.SocialProfile) < prototype(Neos.Fusion:Compone
 
     renderer = afx`
         <script type="application/ld+json">
-            <Neos.Seo:StructuredData.RootObject type={props.type} url={siteUrl} profiles={props.profiles} @children="renderer.sameAs">
+            <Neos.Seo:StructuredData.RootObject type={props.type} url={siteUrl} profiles={props.profiles}
+                                                url={props.siteUrl} logo={props.logo} @children="renderer.sameAs">
                 <Neos.Fusion:RawCollection collection={props.profiles} itemName="profile"
                                            iterationName="iteration" itemRenderer={profile}/>
             </Neos.Seo:StructuredData.RootObject>


### PR DESCRIPTION
With this change the social profile of the site owner can be rendered as structured data.
Most options are configured by overriding the `Settings.yaml` the rest is done automatically.

The behavior is disabled by default.