### PR TITLE
FEATURE: Optional output of searchbox as structured data

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -90,6 +90,22 @@ You can enable this feature with the following code::
 
     prototype(Neos.Seo:StructuredData.Container).breadcrumb.@if.enabled = true
 
+Website & Searchbox
+^^^^^^^^^^^^^^^^^^^
+
+To output general information including url and name of your site you can enable the `Website` object::
+
+    prototype(Neos.Seo:StructuredData.Container).website.@if.enabled = true
+
+Additionally if you have a local search on your site you can enable the `Sitelinks Searchbox` object.
+More information is available here: https://developers.google.com/search/docs/data-types/sitelinks-searchbox
+
+You can enable this feature with the following code and by adjusting `targetNode`::
+
+    prototype(Neos.Seo:StructuredData.Website) {
+        searchAction.targetNode = ${<reference to your search page>}
+    }
+
 Social profile
 ^^^^^^^^^^^^^^
 

--- a/Resources/Private/Fusion/StructuredData/StructuredDataContainer.fusion
+++ b/Resources/Private/Fusion/StructuredData/StructuredDataContainer.fusion
@@ -4,4 +4,7 @@ prototype(Neos.Seo:StructuredData.Container) < prototype(Neos.Fusion:Array) {
 
     socialProfile = Neos.Seo:StructuredData.SocialProfile
     socialProfile.@if.enabled = false
+
+    website = Neos.Seo:StructuredData.Website
+    website.@if.enabled = false
 }

--- a/Resources/Private/Fusion/StructuredData/StructuredDataWebsite.fusion
+++ b/Resources/Private/Fusion/StructuredData/StructuredDataWebsite.fusion
@@ -1,0 +1,18 @@
+prototype(Neos.Seo:StructuredData.Website) < prototype(Neos.Fusion:Component) {
+    @if.onHomepage = ${documentNode == site}
+
+    name = ${site.label}
+    url = Neos.Neos:NodeUri {
+        absolute = true
+        node = ${site}
+    }
+
+    searchAction = Neos.Seo:StructuredData.Website.SearchAction
+
+    renderer = afx`
+        <script type="application/ld+json">
+            <Neos.Seo:StructuredData.RootObject type="WebSite" renderer.name={props.data.name} renderer.url={props.data.url}
+                renderer.potentialAction={props.data.searchAction} renderer.potentialAction.@if.isSet={props.data.searchAction}/>
+        </script>
+    `
+}

--- a/Resources/Private/Fusion/StructuredData/StructuredDataWebsiteSearchAction.fusion
+++ b/Resources/Private/Fusion/StructuredData/StructuredDataWebsiteSearchAction.fusion
@@ -1,0 +1,15 @@
+prototype(Neos.Seo:StructuredData.Website.SearchAction) < prototype(Neos.Fusion:Component) {
+    @if.hasTargetNode = ${this.targetNode}
+
+    targetNode = null
+    queryInput = 'required name=search_term_string'
+    queryParameters = Neos.Fusion:RawArray {
+        search = '\{search_term_string\}'
+    }
+
+    renderer = afx`
+        <Neos.Seo:StructuredData.Object type="SearchAction" @children="renderer.target" renderer.query-input={props.data.queryInput}>
+            <Neos.Neos:NodeUri absolute={true} node={props.data.targetNode} additionalParams={props.data.queryParameters}/>
+        </Neos.Seo:StructuredData.Object>
+    `
+}


### PR DESCRIPTION
This change allows the user to activate output of the searchbox metadata to enable Google to render an in site search. 

See details on https://developers.google.com/search/docs/data-types/sitelinks-searchbox