### PR TITLE
BUGFIX: make sure canonical links are not rendered if node is of type Neos.Seo:NoindexMixin

### DIFF
--- a/Resources/Private/Fusion/Metadata/CanonicalLink.fusion
+++ b/Resources/Private/Fusion/Metadata/CanonicalLink.fusion
@@ -8,5 +8,5 @@ prototype(Neos.Seo:CanonicalLink) < prototype(Neos.Fusion:Tag) {
         }
         href.@process.canonical = ${q(node).property('canonicalLink') ? q(node).property('canonicalLink') : value}
     }
-    @if.hideIfNoIndexIsSet = ${q(node).property('metaRobotsNoindex') ? false : true}
+    @if.hideIfNoIndexIsSet = ${q(node).property('metaRobotsNoindex') || q(node).is('[instanceof Neos.Seo:NoindexMixin]') ? false : true}
 }


### PR DESCRIPTION
this is a follow up for #90 