### PR TITLE
FEATURE: Render og:site_name og:locale and fb:admins tags

### DIFF
--- a/Configuration/Settings.Neos.yaml
+++ b/Configuration/Settings.Neos.yaml
@@ -1,0 +1,18 @@
+Neos:
+  Flow:
+    mvc:
+      routes:
+        # Override this to false to not add the SEO routes.
+        'Neos.Seo':
+          variables:
+            # Override this to change the uri to the sitemap
+            xmlSitemapPath: 'sitemap.xml'
+  Neos:
+    fusion:
+      autoInclude:
+        'Neos.Seo': true
+
+    userInterface:
+      translation:
+        autoInclude:
+          'Neos.Seo': ['NodeTypes/*']

--- a/Configuration/Settings.Seo.yaml
+++ b/Configuration/Settings.Seo.yaml
@@ -1,22 +1,4 @@
 Neos:
-  Flow:
-    mvc:
-      routes:
-        # Override this to false to not add the SEO routes.
-        'Neos.Seo':
-          variables:
-            # Override this to change the uri to the sitemap
-            xmlSitemapPath: 'sitemap.xml'
-  Neos:
-    fusion:
-      autoInclude:
-        'Neos.Seo': true
-
-    userInterface:
-      translation:
-        autoInclude:
-          'Neos.Seo': ['NodeTypes/*']
-
   Seo:
     # robots.txt settings
     robotsTxt:

--- a/Configuration/Settings.Seo.yaml
+++ b/Configuration/Settings.Seo.yaml
@@ -7,7 +7,10 @@ Neos:
     twitterCard:
       # the Twitter handle for the twitter:site attribution
       siteHandle: ~
-
+    # Facebook settings
+    facebook:
+      # List of facebook user ids of your pages/apps administrators
+      admins: []
     # Social profile for the structured data object
     socialProfile:
       # `type` can be either `Person` or `Organization`

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -45,6 +45,21 @@ The `twitter:site` handle can be configured with the setting `Neos.Seo.twitterCa
 
 Check the documentation on https://dev.twitter.com/cards/overview for more on Twitter Cards.
 
+Facebook
+--------
+
+The `fb:admins` handle can be configured with the setting `Neos.Seo.facebook.admins` by providing fb user ids::
+
+  Neos:
+    Seo:
+      facebook:
+        admins:
+          - 'myAdmin1'
+          - 'myAdmin2'
+
+Check the documentation on https://developers.facebook.com/docs/reference/opengraph/object-type/article for more on
+facebook specific tags.
+
 Open Graph
 ----------
 

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -68,15 +68,19 @@ configure Open Graph on any document.
 The Open Graph protocol enables any web page to become a rich object in a social graph. The essential ones are:
 
 * `og:type`
+* `og:site_name`
 * `og:title`
+* `og:locale`
 * `og:description`
 * `og:image`
 * `og:url`
+
 
 In general Open Graph tags are just shown if they have given data, because otherwise Facebook for example will extract data for the generated view from the site itself. So fallbacks are not needed. If you are not satisfied with the generated view you should define your own.
 If a Open Graph Type is enabled, the related meta tags will be rendered according to following rules.
 
 * `og:title` is only rendered if it includes data
+* `og:locale` is only rendered if there is a content dimension `language`
 * `og:description` will use `meta:description` as a fallback or show nothing
 * `og:url` the URL of the document
 * `og:image` is only rendered if it includes data

--- a/Resources/Private/Fusion/Metadata/FacebookMetaTags.fusion
+++ b/Resources/Private/Fusion/Metadata/FacebookMetaTags.fusion
@@ -1,5 +1,6 @@
 prototype(Neos.Seo:FacebookMetaTags) < prototype(Neos.Fusion:Component) {
-    facebookAdmins = ${Array.join(Configuration.setting('Neos.Seo.facebook.admins'))}
+    facebookAdmins = ${Configuration.setting('Neos.Seo.facebook.admins')}
+    facebookAdmins.@process.convertToString = ${Type.isArray(value) ? Array.join(value) : value}
 
     renderer = afx`
         <meta property="fb:admins" content={props.facebookAdmins}/>

--- a/Resources/Private/Fusion/Metadata/FacebookMetaTags.fusion
+++ b/Resources/Private/Fusion/Metadata/FacebookMetaTags.fusion
@@ -1,0 +1,9 @@
+prototype(Neos.Seo:FacebookMetaTags) < prototype(Neos.Fusion:Component) {
+    facebookAdmins = ${Array.join(Configuration.setting('Neos.Seo.facebook.admins'))}
+
+    renderer = afx`
+        <meta @key="admins" property="fb:admins" content={props.facebookAdmins}/>
+    `
+
+    @if.hasAdmins = ${this.facebookAdmins}
+}

--- a/Resources/Private/Fusion/Metadata/FacebookMetaTags.fusion
+++ b/Resources/Private/Fusion/Metadata/FacebookMetaTags.fusion
@@ -2,7 +2,7 @@ prototype(Neos.Seo:FacebookMetaTags) < prototype(Neos.Fusion:Component) {
     facebookAdmins = ${Array.join(Configuration.setting('Neos.Seo.facebook.admins'))}
 
     renderer = afx`
-        <meta @key="admins" property="fb:admins" content={props.facebookAdmins}/>
+        <meta property="fb:admins" content={props.facebookAdmins}/>
     `
 
     @if.hasAdmins = ${this.facebookAdmins}

--- a/Resources/Private/Fusion/Metadata/OpenGraphMetaTags.fusion
+++ b/Resources/Private/Fusion/Metadata/OpenGraphMetaTags.fusion
@@ -10,6 +10,14 @@ prototype(Neos.Seo:OpenGraphMetaTags) < prototype(Neos.Fusion:Array) {
         }
     }
 
+    openGraphSiteNameTag = Neos.Fusion:Tag {
+        tagName = 'meta'
+        attributes {
+            property = 'og:site_name'
+            content = ${site.label}
+        }
+    }
+
     openGraphTitleTag = Neos.Fusion:Tag {
         tagName = 'meta'
         @context.openGraphTitle = ${q(node).property('openGraphTitle')}

--- a/Resources/Private/Fusion/Metadata/OpenGraphMetaTags.fusion
+++ b/Resources/Private/Fusion/Metadata/OpenGraphMetaTags.fusion
@@ -14,7 +14,7 @@ prototype(Neos.Seo:OpenGraphMetaTags) < prototype(Neos.Fusion:Array) {
         tagName = 'meta'
         attributes {
             property = 'og:site_name'
-            content = ${site.label}
+            content = ${q(site).property('titleOverride') || site.label}
         }
     }
 

--- a/Resources/Private/Fusion/Metadata/OpenGraphMetaTags.fusion
+++ b/Resources/Private/Fusion/Metadata/OpenGraphMetaTags.fusion
@@ -18,6 +18,16 @@ prototype(Neos.Seo:OpenGraphMetaTags) < prototype(Neos.Fusion:Array) {
         }
     }
 
+    openGraphLocaleTag = Neos.Fusion:Tag {
+        tagName = 'meta'
+        @context.openGraphLocale = Neos.Seo:LangAttribute
+        attributes {
+            property = 'og:locale'
+            content = ${openGraphLocale}
+        }
+        @if.isNotBlank = ${!String.isBlank(openGraphLocale)}
+    }
+
     openGraphTitleTag = Neos.Fusion:Tag {
         tagName = 'meta'
         @context.openGraphTitle = ${q(node).property('openGraphTitle')}

--- a/Resources/Private/Fusion/Page.fusion
+++ b/Resources/Private/Fusion/Page.fusion
@@ -10,6 +10,7 @@ prototype(Neos.Neos:Page) {
         alternateLanguageLinks = Neos.Seo:AlternateLanguageLinks
         twitterCard = Neos.Seo:TwitterCard
         openGraphMetaTags = Neos.Seo:OpenGraphMetaTags
+        facebookMetaTags = Neos.Seo:FacebookMetaTags
         structuredData = Neos.Seo:StructuredData.Container
     }
 }


### PR DESCRIPTION
This change introduces three additional opengraph/facebook tags to solve #82, #83, #84.

* `og:locale` and `og:site_name` are determined automatically.
* `fb:admins` can be configured via the `Settings.yaml` and needs an array of strings.

To fully test everything a site with a language dimension is needed and the admins property in the settings set up with an array of some random strings.