### PR TITLE
!!! FEATURE: Make titletag configurable and always append suffix

### DIFF
--- a/Resources/Private/Fusion/Metadata/TitleTag.fusion
+++ b/Resources/Private/Fusion/Metadata/TitleTag.fusion
@@ -1,15 +1,32 @@
-prototype(Neos.Seo:TitleTag) < prototype(Neos.Fusion:Tag) {
-    tagName = 'title'
-    default = Neos.Fusion:Collection {
-        // Retrieve all parent document nodes excluding the homepage
-        collection = ${q(documentNode).add(q(documentNode).parents()).slice(0, -1).get()}
-        itemName = 'node'
-        iterationName = 'nodeIterator'
-        // Implode node titles with a dash
-        itemRenderer = ${q(node).property('title') + (nodeIterator.isLast ? '' : ' - ')}
-        // Always add general site name as suffix
-        @process.siteName = ${(value ? String.stripTags(value) + ' - ' : '') + site.context.currentSite.name}
+prototype(Neos.Seo:TitleTag) < prototype(Neos.Fusion:Component) {
+    suffix = ${site.context.currentSite.name}
+
+    title = Neos.Fusion:Case {
+        titleOverride {
+            condition = ${q(node).property('titleOverride')}
+            renderer = ${q(node).property('titleOverride')}
+            @position = 'start'
+        }
+
+        default {
+            condition = true
+            @position = 'end'
+            renderer = Neos.Fusion:Collection {
+                // Retrieve all parent document nodes excluding the homepage
+                collection = ${q(documentNode).add(q(documentNode).parents('[instanceof Neos.Neos:Document]')).get()}
+                collection.@process.removeSiteNode = ${Array.slice(value, 0, -1)}
+                collection.@process.removeSiteNode.@if.onSubPage = ${documentNode != site}
+                itemName = 'node'
+                iterationName = 'nodeIterator'
+                // Implode node titles with a dash
+                itemRenderer = ${q(node).property('title') + (nodeIterator.isLast ? '' : ' - ')}
+            }
+        }
+
+        @process.stripTags = ${String.stripTags(value)}
     }
 
-    content = ${q(node).property('titleOverride') ? q(node).property('titleOverride') : this.default}
+    renderer = afx`
+        <title>{(props.title ? props.title + ' - ' : '') + props.suffix}</title>
+    `
 }

--- a/Resources/Private/Fusion/Metadata/TitleTag.fusion
+++ b/Resources/Private/Fusion/Metadata/TitleTag.fusion
@@ -1,5 +1,8 @@
 prototype(Neos.Seo:TitleTag) < prototype(Neos.Fusion:Component) {
     suffix = ${site.context.currentSite.name}
+    breadcrumbSeparator = ' - '
+    @context.breadcrumbSeparator = ${this.breadcrumbSeparator}
+    suffixSeparator = ${this.breadcrumbSeparator}
 
     title = Neos.Fusion:Case {
         titleOverride {
@@ -19,7 +22,7 @@ prototype(Neos.Seo:TitleTag) < prototype(Neos.Fusion:Component) {
                 itemName = 'node'
                 iterationName = 'nodeIterator'
                 // Implode node titles with a dash
-                itemRenderer = ${q(node).property('title') + (nodeIterator.isLast ? '' : ' - ')}
+                itemRenderer = ${q(node).property('title') + (nodeIterator.isLast ? '' : breadcrumbSeparator)}
             }
         }
 
@@ -27,6 +30,6 @@ prototype(Neos.Seo:TitleTag) < prototype(Neos.Fusion:Component) {
     }
 
     renderer = afx`
-        <title>{(props.title ? props.title + ' - ' : '') + props.suffix}</title>
+        <title>{(props.title ? props.title + props.suffixSeparator : '') + props.suffix}</title>
     `
 }


### PR DESCRIPTION
This will allow configuring a generic suffix for the title tag.
Usually this would be the sites name or something similar.

For specific purposes the title generation can be extended
by providing additional cases in Fusion.

This is breaking as the sitenode will now render it’s own title too,
and previous overrides on the title tag might behave differently.

The title of the sitenode will only appear when visiting the site node but
not on subpages in the titles breadcrumbs.

Resolves: #81