### PR TITLE
FEATURE: Provide and enforce presets for meta images

### DIFF
--- a/Configuration/NodeTypes.Mixin.OpenGraph.yaml
+++ b/Configuration/NodeTypes.Mixin.OpenGraph.yaml
@@ -63,3 +63,18 @@
           editorOptions:
             features:
               crop: true
+            crop:
+              aspectRatio:
+                options:
+                  square:
+                    width: 1200
+                    height: 630
+                  fourFive: ~
+                  fiveSeven: ~
+                  twoThree: ~
+                  fourThree: ~
+                  sixteenNine: ~
+                enableOriginal: false
+                allowCustom: false
+                defaultOption: square
+                forceCrop: true

--- a/Configuration/NodeTypes.Mixin.TwitterCard.yaml
+++ b/Configuration/NodeTypes.Mixin.TwitterCard.yaml
@@ -73,3 +73,23 @@
           editorOptions:
             features:
               crop: true
+            crop:
+              aspectRatio:
+                options:
+                  twoOne:
+                    width: 1200
+                    height: 600
+                    label: 'Summary Card Large Image'
+                  square:
+                    width: 600
+                    height: 600
+                    label: 'Summary Card'
+                  fourFive: ~
+                  fiveSeven: ~
+                  twoThree: ~
+                  fourThree: ~
+                  sixteenNine: ~
+                enableOriginal: false
+                allowCustom: false
+                defaultOption: 'ClientEval: node.properties.twitterCardType == "summary_large_image" ? "twoOne" : "square"'
+                forceCrop: true

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -46,3 +46,15 @@ Neos:
         linkedIn: ~
         youTube: ~
 
+  Media:
+    thumbnailPresets:
+      'Neos.Seo:OpenGraph':
+        maximumWidth: 1200
+        maximumHeight: 630
+      'Neos.Seo:TwitterCard.SummaryCardLargeImage':
+        maximumWidth: 1200
+        maximumHeight: 600
+      'Neos.Seo:TwitterCard.SummaryCard':
+        maximumWidth: 600
+        maximumHeight: 600
+

--- a/Resources/Private/Fusion/Metadata/OpenGraphMetaTags.fusion
+++ b/Resources/Private/Fusion/Metadata/OpenGraphMetaTags.fusion
@@ -61,6 +61,7 @@ prototype(Neos.Seo:OpenGraphMetaTags) < prototype(Neos.Fusion:Array) {
             property = 'og:image'
             content = Neos.Neos:ImageUri {
                 asset = ${openGraphImage}
+                preset = 'Neos.Seo:OpenGraph'
             }
         }
         @if.isImageSet = ${openGraphImage != null && openGraphImage != ''}

--- a/Resources/Private/Fusion/Metadata/TwitterCard.fusion
+++ b/Resources/Private/Fusion/Metadata/TwitterCard.fusion
@@ -58,8 +58,17 @@ prototype(Neos.Seo:TwitterCard) < prototype(Neos.Fusion:Array) {
                         renderer = ${q(node).property('twitterCardImage')}
                     }
                 }
-                maximumWidth = 2000
-                maximumHeight = 2000
+                preset = Neos.Fusion:Case {
+                    summaryCardLargeImage {
+                        condition = ${q(node).property('twitterCardType') == 'summary_large_image'}
+                        renderer = 'Neos.Seo:TwitterCard.SummaryCardLargeImage'
+                    }
+
+                    default {
+                        condition = true
+                        renderer = 'Neos.Seo:TwitterCard.SummaryCard'
+                    }
+                }
             }
         }
         @if.isImageSet = ${q(node).property('twitterCardImage') != null}


### PR DESCRIPTION
This change introduces three presets for meta images.
One for open graph and two for the two types of twitter cards.

When an editor uploads a new image in one of the properties, the UI will
automatically open the crop editor and enforce the correct aspect ratio.

For the twitter card this depends on the choosen type.

In general the output will enforce the preset even if the image comes from a different source than
the document nodes properties.