### PR TITLE
TASK: Add og image landscape variant and output correct image size

### DIFF
--- a/Classes/Fusion/Helper/ImageHelper.php
+++ b/Classes/Fusion/Helper/ImageHelper.php
@@ -1,0 +1,84 @@
+<?php
+namespace Neos\Seo\Fusion\Helper;
+
+/*
+ * This file is part of the Neos.Seo package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Eel\ProtectedContextAwareInterface;
+use Neos\Media\Domain\Model\AssetInterface;
+use Neos\Media\Domain\Model\ImageInterface;
+use Neos\Media\Domain\Model\ThumbnailConfiguration;
+use Neos\Media\Domain\Service\ThumbnailService;
+
+class ImageHelper implements ProtectedContextAwareInterface
+{
+    /**
+     * @Flow\Inject
+     * @var ThumbnailService
+     */
+    protected $thumbnailService;
+
+    /**
+     * @param AssetInterface $asset
+     * @param string $preset Name of the preset that should be used as basis for the configuration
+     * @param integer $width Desired width of the image
+     * @param integer $maximumWidth Desired maximum width of the image
+     * @param integer $height Desired height of the image
+     * @param integer $maximumHeight Desired maximum height of the image
+     * @param boolean $allowCropping Whether the image should be cropped if the given sizes would hurt the aspect ratio
+     * @param boolean $allowUpScaling Whether the resulting image size might exceed the size of the original image
+     * @param boolean $async Whether the thumbnail can be generated asynchronously
+     * @return null|ImageInterface
+     * @throws \Exception
+     */
+    public function createThumbnail(
+        AssetInterface $asset,
+        $preset = null,
+        $width = null,
+        $maximumWidth = null,
+        $height = null,
+        $maximumHeight = null,
+        $allowCropping = false,
+        $allowUpScaling = false,
+        $async = false
+    )
+    {
+        if (!empty($preset)) {
+            $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($preset);
+        } else {
+            $thumbnailConfiguration = new ThumbnailConfiguration(
+                $width,
+                $maximumWidth,
+                $height,
+                $maximumHeight,
+                $allowCropping,
+                $allowUpScaling,
+                $async
+            );
+        }
+        $thumbnailImage = $this->thumbnailService->getThumbnail($asset, $thumbnailConfiguration);
+        if (!$thumbnailImage instanceof ImageInterface) {
+            return null;
+        }
+        return $thumbnailImage;
+    }
+
+    /**
+     * All methods are considered safe
+     *
+     * @param string $methodName
+     * @return boolean
+     */
+    public function allowsCallOfMethod($methodName)
+    {
+        return true;
+    }
+}

--- a/Configuration/NodeTypes.Mixin.OpenGraph.yaml
+++ b/Configuration/NodeTypes.Mixin.OpenGraph.yaml
@@ -67,8 +67,12 @@
               aspectRatio:
                 options:
                   square:
+                    width: 1080
+                    height: 1080
+                  twoOne:
                     width: 1200
-                    height: 630
+                    height: 628
+                    label: 'Landscape'
                   fourFive: ~
                   fiveSeven: ~
                   twoThree: ~
@@ -76,5 +80,5 @@
                   sixteenNine: ~
                 enableOriginal: false
                 allowCustom: false
-                defaultOption: square
+                defaultOption: twoOne
                 forceCrop: true

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -17,6 +17,10 @@ Neos:
         autoInclude:
           'Neos.Seo': ['NodeTypes/*']
 
+  Fusion:
+    defaultContext:
+      'Neos.Seo.Image': 'Neos\Seo\Fusion\Helper\ImageHelper'
+
   Seo:
     # robots.txt settings
     robotsTxt:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -48,12 +48,18 @@ Neos:
 
   Media:
     thumbnailPresets:
-      'Neos.Seo:OpenGraph':
+      # Presets based on https://developers.facebook.com/docs/sharing/best-practices#images
+      'Neos.Seo:OpenGraph.Square':
+        maximumWidth: 1080
+        maximumHeight: 1080
+      'Neos.Seo:OpenGraph.Landscape':
         maximumWidth: 1200
-        maximumHeight: 630
+        maximumHeight: 628
+      # Preset based on https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image
       'Neos.Seo:TwitterCard.SummaryCardLargeImage':
         maximumWidth: 1200
         maximumHeight: 600
+      # Preset based on https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary
       'Neos.Seo:TwitterCard.SummaryCard':
         maximumWidth: 600
         maximumHeight: 600

--- a/Resources/Private/Fusion/Metadata/OpenGraphMetaTags.fusion
+++ b/Resources/Private/Fusion/Metadata/OpenGraphMetaTags.fusion
@@ -17,6 +17,11 @@ prototype(Neos.Seo:OpenGraphMetaTags) < prototype(Neos.Fusion:Component) {
         }
     }
 
+    preset = ${'Neos.Seo:OpenGraph.' + (this.image.isOrientationLandscape ? 'Landscape' : 'Square')}
+    preset.@if.hasImage = ${this.image}
+    thumbnail = ${Neos.Seo.Image.createThumbnail(this.image, this.preset)}
+    thumbnail.@if.hasImage = ${this.image}
+
     renderer = afx`
         <meta @key="type" property="og:type" content={props.type}/>
         <meta @key="title" property="og:title" content={props.title}/>
@@ -26,10 +31,10 @@ prototype(Neos.Seo:OpenGraphMetaTags) < prototype(Neos.Fusion:Component) {
         <meta @key="url" property="og:url" content={props.url}/>
         <Neos.Fusion:Join @key="image" @if.set={props.image}>
             <meta @key="image" property="og:image">
-                <Neos.Neos:ImageUri asset={props.image} preset={'Neos.Seo:OpenGraph.' + (props.image.isOrientationSquare ? 'Square' : 'Landscape')} @path='attributes.content'/>
+                <Neos.Fusion:ResourceUri resource={props.thumbnail.resource} @path='attributes.content'/>
             </meta>
-            <meta @key="width" property="og:image:width" content={props.image.width}/>
-            <meta @key="height" property="og:image:height" content={props.image.height}/>
+            <meta @key="width" property="og:image:width" content={props.thumbnail.width}/>
+            <meta @key="height" property="og:image:height" content={props.thumbnail.height}/>
             <meta @key="alt" property="og:image:alt" content={props.image.label} @if.set={props.image.label}/>
         </Neos.Fusion:Join>
     `

--- a/Resources/Private/Fusion/Metadata/OpenGraphMetaTags.fusion
+++ b/Resources/Private/Fusion/Metadata/OpenGraphMetaTags.fusion
@@ -26,7 +26,7 @@ prototype(Neos.Seo:OpenGraphMetaTags) < prototype(Neos.Fusion:Component) {
         <meta @key="url" property="og:url" content={props.url}/>
         <Neos.Fusion:Join @key="image" @if.set={props.image}>
             <meta @key="image" property="og:image">
-                <Neos.Neos:ImageUri asset={props.image} preset='Neos.Seo:OpenGraph'  @path='attributes.content'/>
+                <Neos.Neos:ImageUri asset={props.image} preset={'Neos.Seo:OpenGraph.' + (props.image.isOrientationSquare ? 'Square' : 'Landscape')} @path='attributes.content'/>
             </meta>
             <meta @key="width" property="og:image:width" content={props.image.width}/>
             <meta @key="height" property="og:image:height" content={props.image.height}/>


### PR DESCRIPTION
Adds the non square image variant for open graph images and notes where to find image size definitions in the `Settings.yaml`.

This will also introduce a new Eel ImageHelper to generate a thumbnail to be able to get the rendered image size in fusion.

Can be checked after #109 is merged.