### PR TITLE
!!! TASK: Render alternate language links and sitemap list with fusion and allow excluding presets

### DIFF
--- a/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
+++ b/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
@@ -9,6 +9,10 @@ prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Fusion:Component) {
     dimensionConfiguration = ${Configuration.setting('Neos.ContentRepository.contentDimensions.' + this.dimension)}
     excludedPresets = ${[]}
 
+    # The hreflang value needs to have a format like 'en-US', therefore internally used values
+    # like 'en_US' will be modified to match.
+    dimensionValueSeparator = '_'
+
     renderer = Neos.Fusion:Loop {
         items = Neos.Neos:DimensionsMenuItems {
             dimension = ${props.dimension}
@@ -18,7 +22,7 @@ prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Fusion:Component) {
                 @if.isDefaultLocale={props.defaultLocale == item.dimensions[props.dimension][0]}/>
             <Neos.Seo:AlternateLanguageLink node={item.node}
                 @if.notExcluded={!props.excludedPresets || Array.indexOf(props.excludedPresets, item.dimensions[props.dimension][0]) == -1}
-                hreflang={String.replace((item.preset ? item.preset.values[0] : item.dimensions[props.dimension][0]), '_', '-')}/>
+                hreflang={String.replace((item.preset ? item.preset.values[0] : item.dimensions[props.dimension][0]), props.dimensionValueSeparator, '-')}/>
         `
     }
 }

--- a/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
+++ b/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
@@ -1,4 +1,4 @@
-prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Neos:DimensionsMenu) {
+prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Fusion:Component) {
     @if.languageDimensionExists = ${this.dimensionConfiguration != null}
     @if.onlyRenderWhenInLiveWorkspace = ${this.node.context.workspace.name == 'live'}
     @if.hasNoForeignCanonical = ${String.isBlank(q(this.node).property('canonicalLink'))}
@@ -7,19 +7,16 @@ prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Neos:DimensionsMenu)
     dimension = 'language'
     defaultLocale = ${Configuration.setting('Neos.ContentRepository.contentDimensions.' + this.dimension + '.default')}
     dimensionConfiguration = ${Configuration.setting('Neos.ContentRepository.contentDimensions.' + this.dimension)}
-    templatePath = 'resource://Neos.Seo/Private/Fusion/Metadata/AlternateLanguageLinks.html'
 
-    @context {
-        items = ${this.items}
-        items.@if.hasValidDimension = ${this.dimensionConfiguration != null}
-        defaultLocale = ${this.defaultLocale}
-        dimension = ${this.dimension}
+    renderer = Neos.Fusion:Loop {
+        items = Neos.Neos:DimensionsMenuItems {
+            dimension = ${props.dimension}
+        }
+        itemRenderer = afx`
+            <Neos.Seo:AlternateLanguageLink @key="defaultLink" node={item.node} hreflang="x-default"
+                @if.isDefaultLocale={props.defaultLocale == item.dimensions[props.dimension][0]}/>
+            <Neos.Seo:AlternateLanguageLink node={item.node}
+                hreflang={String.replace((item.preset ? item.preset.values[0] : item.dimensions[props.dimension][0]), '_', '-')}/>
+        `
     }
-
-    links = afx`
-        <Neos.Fusion:Collection collection={items} itemName="item" @children="itemRenderer">
-            <Neos.Seo:AlternateLanguageLink @key="defaultLink" node={item.node} hreflang="x-default" @if.isDefaultLocale={defaultLocale == item.dimensions[dimension][0]}/>
-            <Neos.Seo:AlternateLanguageLink node={item.node} hreflang={String.replace((item.preset ? item.preset.values[0] : item.dimensions[dimension][0]), '_', '-')}/>
-        </Neos.Fusion:Collection>
-    `
 }

--- a/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
+++ b/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
@@ -7,6 +7,7 @@ prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Fusion:Component) {
     dimension = 'language'
     defaultLocale = ${Configuration.setting('Neos.ContentRepository.contentDimensions.' + this.dimension + '.default')}
     dimensionConfiguration = ${Configuration.setting('Neos.ContentRepository.contentDimensions.' + this.dimension)}
+    excludedPresets = ${[]}
 
     renderer = Neos.Fusion:Loop {
         items = Neos.Neos:DimensionsMenuItems {
@@ -16,6 +17,7 @@ prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Fusion:Component) {
             <Neos.Seo:AlternateLanguageLink @key="defaultLink" node={item.node} hreflang="x-default"
                 @if.isDefaultLocale={props.defaultLocale == item.dimensions[props.dimension][0]}/>
             <Neos.Seo:AlternateLanguageLink node={item.node}
+                @if.notExcluded={!props.excludedPresets || Array.indexOf(props.excludedPresets, item.dimensions[props.dimension][0]) == -1}
                 hreflang={String.replace((item.preset ? item.preset.values[0] : item.dimensions[props.dimension][0]), '_', '-')}/>
         `
     }

--- a/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.html
+++ b/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.html
@@ -1,2 +1,0 @@
-{namespace fusion=Neos\Fusion\ViewHelpers}
-<fusion:render path="links"/>

--- a/Resources/Private/Fusion/RobotsTxt/RobotsTxt.fusion
+++ b/Resources/Private/Fusion/RobotsTxt/RobotsTxt.fusion
@@ -9,19 +9,25 @@ prototype(Neos.Seo:RobotsTxt) < prototype(Neos.Fusion:Component) {
     renderXMLSitemapLinks = true
     languageDimension = 'language'
     dimensionsPresets = ${Configuration.setting('Neos.Seo.robotsTxt.dimensionsPresets')}
+    linebreak = '
+'
 
     renderer = Neos.Fusion:Component {
-
         sitemaps = Neos.Fusion:Case {
             @if.shouldRender = ${props.renderXMLSitemapLinks}
             hasLanguage {
                 condition = ${Configuration.setting('Neos.ContentRepository.contentDimensions.' + props.languageDimension) != null}
-                renderer = Neos.Neos:DimensionsMenu {
-                    dimension = ${props.languageDimension}
-                    templatePath = 'resource://Neos.Seo/Private/Fusion/RobotsTxt/Sitemap.html'
-                    presets = ${props.dimensionsPresets}
-                    renderHiddenInIndex = true
-                    includeAllPresets = true
+                renderer = Neos.Fusion:Loop {
+                    items = Neos.Neos:DimensionsMenuItems {
+                        dimension = ${props.languageDimension}
+                        includeAllPresets = true
+                    }
+                    itemRenderer = Neos.Neos:NodeUri {
+                        absolute = true
+                        format = 'xml.sitemap'
+                        node = ${item.node}
+                        @process.prefix = ${'Sitemap: ' + value + props.linebreak}
+                    }
                 }
             }
             noLanguage {
@@ -36,15 +42,14 @@ prototype(Neos.Seo:RobotsTxt) < prototype(Neos.Fusion:Component) {
         }
 
         data = ${props.data}
+        linebreak = ${props.linebreak}
 
-        linebreak = '
-'
         renderer = Neos.Fusion:Http.Message {
             httpResponseHead.headers.Content-Type = 'text/plain;'
             body = afx`
-                <Neos.Fusion:Collection collection={props.data} @children='itemRenderer'>
+                <Neos.Fusion:Loop items={props.data} @children='itemRenderer'>
                     {item}{props.linebreak}
-                </Neos.Fusion:Collection>
+                </Neos.Fusion:Loop>
                 {props.sitemaps}
             `
         }

--- a/Resources/Private/Fusion/RobotsTxt/RobotsTxt.fusion
+++ b/Resources/Private/Fusion/RobotsTxt/RobotsTxt.fusion
@@ -9,8 +9,8 @@ prototype(Neos.Seo:RobotsTxt) < prototype(Neos.Fusion:Component) {
     renderXMLSitemapLinks = true
     languageDimension = 'language'
     dimensionsPresets = ${Configuration.setting('Neos.Seo.robotsTxt.dimensionsPresets')}
-    linebreak = '
-'
+    excludedDimensionPresets = ${[]}
+    linebreak = ${String.chr(10)}
 
     renderer = Neos.Fusion:Component {
         sitemaps = Neos.Fusion:Case {
@@ -27,6 +27,7 @@ prototype(Neos.Seo:RobotsTxt) < prototype(Neos.Fusion:Component) {
                         format = 'xml.sitemap'
                         node = ${item.node}
                         @process.prefix = ${'Sitemap: ' + value + props.linebreak}
+                        @if.notExcluded = ${!props.excludedDimensionPresets || Array.indexOf(props.excludedDimensionPresets, item.dimensions[props.languageDimension][0]) == -1}
                     }
                 }
             }
@@ -47,7 +48,7 @@ prototype(Neos.Seo:RobotsTxt) < prototype(Neos.Fusion:Component) {
         renderer = Neos.Fusion:Http.Message {
             httpResponseHead.headers.Content-Type = 'text/plain;'
             body = afx`
-                <Neos.Fusion:Loop items={props.data} @children='itemRenderer'>
+                <Neos.Fusion:Loop items={props.data}>
                     {item}{props.linebreak}
                 </Neos.Fusion:Loop>
                 {props.sitemaps}

--- a/Resources/Private/Fusion/RobotsTxt/Sitemap.html
+++ b/Resources/Private/Fusion/RobotsTxt/Sitemap.html
@@ -1,3 +1,0 @@
-{namespace neos=Neos\Neos\ViewHelpers}
-<f:for each="{items}" as="item"><f:if condition="{item.node}">Sitemap: <neos:uri.node node="{item.node}" format="xml.sitemap" absolute="true" />
-</f:if></f:for>

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "description": "SEO configuration and tools for Neos",
     "license": "GPL-3.0-or-later",
     "require": {
-        "neos/neos": "~3.3 || ~4.0 || dev-master",
-        "neos/fusion-afx": "~1.0 || dev-master"
+        "neos/neos": "~4.3 || dev-master",
+        "neos/fusion-afx": "~1.2 || dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This change raises the minimum Neos version to 4.3 as the new prototype `Neos.Neos:DimensionsMenuItems` is required to get rid of the last fluid templates.

Now it's also possible to exclude presets to solve #101 