### PR TITLE
BUGFIX: Missing profiles break social profile

### DIFF
--- a/Resources/Private/Fusion/StructuredData/RootObjects/SocialProfile.fusion
+++ b/Resources/Private/Fusion/StructuredData/RootObjects/SocialProfile.fusion
@@ -25,7 +25,8 @@ prototype(Neos.Seo:StructuredData.SocialProfile) < prototype(Neos.Fusion:Compone
     linkedIn.@if.set = ${this.profiles.linkedIn}
 
     urls = ${[this.twitter, this.facebook, this.instagram, this.youTube, this.linkedIn]}
-    urls.@process.filter = ${Array.filter(value, url => !!url)}
+    urls.@process.filter = ${Array.reduce(value, (items, url) => !!url ? Array.push(items, url) : items, [])}
+    urls.@process.filter.@position = 'end'
 
     renderer = afx`
         <Neos.Seo:StructuredData.RootObject type={props.type}>


### PR DESCRIPTION
See also https://github.com/neos/flow-development-collection/issues/1568

When a profile is not set, it can happen that `urls` turned into an associative array which breaks the structured data output.