### PR TITLE
BUGFIX: Don't render alternate language links without translated content

### DIFF
--- a/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
+++ b/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
@@ -21,6 +21,7 @@ prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Fusion:Component) {
             <Neos.Seo:AlternateLanguageLink @key="defaultLink" node={item.node} hreflang="x-default"
                 @if.isDefaultLocale={props.defaultLocale == item.dimensions[props.dimension][0]}/>
             <Neos.Seo:AlternateLanguageLink node={item.node}
+                @if.isNotAbsent={item.state != 'absent'}
                 @if.notExcluded={!props.excludedPresets || Array.indexOf(props.excludedPresets, item.dimensions[props.dimension][0]) == -1}
                 hreflang={String.replace((item.preset ? item.preset.values[0] : item.dimensions[props.dimension][0]), props.dimensionValueSeparator, '-')}/>
         `


### PR DESCRIPTION
Currently the alternate language links would render links even if a page is not translated.
With this change, these links will not be in the output anymore.