### PR TITLE
Use ISO 8601 for lastMod (which adds seconds)

### DIFF
--- a/Resources/Private/Fusion/XmlSitemap/XmlSitemapUrl.fusion
+++ b/Resources/Private/Fusion/XmlSitemap/XmlSitemapUrl.fusion
@@ -1,7 +1,7 @@
 prototype(Neos.Seo:XmlSitemap.Url) < prototype(Neos.Fusion:Component) {
     node = null
     lastModificationDateTime = ${Date.now()}
-    lastModificationDateTime.@process.format = ${Date.format(value, 'Y-m-d\TH:iP')}
+    lastModificationDateTime.@process.format = ${Date.format(value, 'c')}
     changeFrequency = ''
     priority = ''
     images = ${[]}


### PR DESCRIPTION
Currently, the `lastMod` in all Sitemaps is displayed without seconds and leads to errors with a few SEO tools, but possibly also with a few (smaller) search engines.

To display the date standardised, I adapted the date format to the [ISO 8601 date](https://www.php.net/manual/de/function.date.php), which is common used.

The current Date is e.g.: `2019-06-06T11:13+02:00`

With the format change it would be: `2019-06-06T11:13:45+02:00`

As you can see, the only change is that additional seconds are displayed.