### PR TITLE
BUGFIX: Add missing type for no index mixin

### DIFF
--- a/Configuration/NodeTypes.Mixin.NoIndex.yaml
+++ b/Configuration/NodeTypes.Mixin.NoIndex.yaml
@@ -5,6 +5,7 @@
   abstract: true
   properties:
     metaRobotsNoindex:
+      type: boolean
       defaultValue: true
       ui:
         inspector:


### PR DESCRIPTION
This causes warnings or might even cause errors for node types
like Shortcuts where Neos.Seo:SeoMetaTagsMixin is deactivated but
no index is activated.
In this case the type was missing from the property configuration.