### PR TITLE
FEATURE: Add robots.txt disallow

### DIFF
--- a/Classes/EelHelper/ArrayHelper.php
+++ b/Classes/EelHelper/ArrayHelper.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Neos\Seo\EelHelper;
+
+
+/*
+ * This file is part of the Neos.Seo package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Eel\ProtectedContextAwareInterface;
+
+/**
+ * @Flow\Proxy(false)
+ */
+class ArrayHelper implements ProtectedContextAwareInterface
+{
+
+    /**
+     * Removes duplicate values from an array
+     *
+     * @param array $array  The array
+     * @param bool  $filter Filter the array defaults to `false`
+     * 
+     * @return array
+     */
+    public function unique(array $array, bool $filter = false): array
+    {
+        if ($filter) {
+            $array = array_filter($array);
+        }
+        return array_unique($array);
+    }
+    /**
+     * All methods are considered safe
+     * 
+     * @param string $methodName The name of the method
+     * 
+     * @return bool
+     */
+    public function allowsCallOfMethod($methodName)
+    {
+        return true;
+    }
+}

--- a/Configuration/NodeTypes.Mixin.SeoMetaTags.yaml
+++ b/Configuration/NodeTypes.Mixin.SeoMetaTags.yaml
@@ -52,3 +52,13 @@
         inspector:
           group: 'seometa'
           position: 40
+    robotsDisallow:
+      type: boolean
+      ui:
+        label: i18n
+        help:
+          message: i18n
+        inspector:
+          hidden: 'ClientEval:node.properties.metaRobotsNoindex && node.properties.metaRobotsNofollow ? false : true'
+          group: seometa
+          position: 50

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -20,6 +20,7 @@ Neos:
   Fusion:
     defaultContext:
       'Neos.Seo.Image': 'Neos\Seo\Fusion\Helper\ImageHelper'
+      'Neos.Seo.Array': 'Carbon\Eel\EelHelper\ArrayHelper'
 
   Seo:
     # robots.txt settings

--- a/Resources/Private/Fusion/RobotsTxt/Fragment/Disallow.fusion
+++ b/Resources/Private/Fusion/RobotsTxt/Fragment/Disallow.fusion
@@ -1,0 +1,19 @@
+prototype(Neos.Seo:RobotsTxt.Fragment.Disallow) < prototype(Neos.Fusion:Component) {
+    node = ${site}
+    filter = '[instanceof Neos.Neos:Document][metaRobotsNoindex = true][metaRobotsNofollow = true][robotsDisallow = true]'
+
+    items = ${q(this.node).find(this.filter).add(q(this.node).filter(this.filter)).get()}
+    @if.hasItems = ${Array.length(this.items)}
+
+    renderer = Neos.Fusion:Map {
+        items = ${props.items}
+        itemRenderer = Neos.Neos:NodeUri {
+            node = ${item}
+            parent = ${q(item).parents(props.filter).count()}
+            format = 'html'
+           @process.prefix = ${!this.parent && value ? 'Disallow: ' + value : false}
+        }
+        @process.uniqueAndJoin = ${Array.join(Neos.Seo.Array.unique(value, true), String.chr(10))}
+    }
+}
+

--- a/Resources/Private/Fusion/RobotsTxt/RobotsTxt.fusion
+++ b/Resources/Private/Fusion/RobotsTxt/RobotsTxt.fusion
@@ -42,7 +42,25 @@ prototype(Neos.Seo:RobotsTxt) < prototype(Neos.Fusion:Component) {
                 }
             }
         }
-
+        disallowedDocuments = Neos.Fusion:Case {
+            hasLanguage {
+                condition = ${Configuration.setting('Neos.ContentRepository.contentDimensions.' + props.languageDimension) != null}
+                renderer = Neos.Fusion:Map {
+                    items = Neos.Neos:DimensionsMenuItems {
+                        dimension = ${props.languageDimension}
+                        includeAllPresets = true
+                    }
+                    itemRenderer = Neos.Seo:RobotsTxt.Fragment.Disallow {
+                        node = ${item.node}
+                    }
+                    @process.uniqueAndJoin = ${Array.join(Neos.Seo.Array.unique(value, true), String.chr(10))}
+                }
+            }
+            noLanguage {
+                condition = true
+                renderer = Neos.Seo:RobotsTxt.Fragment.Disallow
+            }
+        }
         data = ${props.data}
         linebreak = ${props.linebreak}
 
@@ -52,6 +70,8 @@ prototype(Neos.Seo:RobotsTxt) < prototype(Neos.Fusion:Component) {
                 <Neos.Fusion:Loop items={props.data}>
                     {item}{props.linebreak}
                 </Neos.Fusion:Loop>
+                {props.disallowedDocuments}
+                {props.disallowedDocuments ? props.linebreak : ''}
                 {props.sitemaps}
             `
         }

--- a/Resources/Private/Translations/de/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/SeoMetaTagsMixin.xlf
@@ -23,6 +23,12 @@
       <trans-unit id="properties.metaRobotsNofollow" xml:space="preserve" approved="yes">
 				<source>Do not follow links (nofollow)</source>
 			<target state="final">Links nicht folgen (nofollow)</target></trans-unit>
+      <trans-unit id="properties.robotsDisallow" xml:space="preserve">
+				<source>Disallow page also in robots.txt</source>
+			<target>Seite auch im robots.txt verbieten</target></trans-unit>
+      <trans-unit id="properties.robotsDisallow.ui.help.message" xml:space="preserve">
+				<source>HELP TEXT FOR robotsDisallow</source>
+			<target>HELP TEXT FOR robotsDisallow</target></trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/en/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/SeoMetaTagsMixin.xlf
@@ -23,6 +23,12 @@
 			<trans-unit id="properties.metaRobotsNofollow" xml:space="preserve">
 				<source>Do not follow links (nofollow)</source>
 			</trans-unit>
+			<trans-unit id="properties.robotsDisallow" xml:space="preserve">
+				<source>Disallow page also in robots.txt</source>
+			</trans-unit>
+			<trans-unit id="properties.robotsDisallow.ui.help.message" xml:space="preserve">
+				<source>HELP TEXT FOR robotsDisallow</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>


### PR DESCRIPTION
With this change, the editor can also exclude the document in `robots.txt`. The `noindex` and `nofollow` tags are more recommendations, but with the declaration in `robots.txt`, it is a precise instruction for the search engines. 

After some conversions with some SEO experts they recommend to have this as own property and not set it automatically if `noindex` and `nofollow` are set


## To do
- [ ] Add documentation
- [ ] Add labels and help message
- [ ] Exclude sitemap if the property is set on `site`
- [ ] Exclude sub-paths from sitemap