### PR TITLE
BUGFIX: Invalidate sitemap caches properly

### DIFF
--- a/Resources/Private/Fusion/XmlSitemap/XmlSitemap.fusion
+++ b/Resources/Private/Fusion/XmlSitemap/XmlSitemap.fusion
@@ -20,9 +20,16 @@ prototype(Neos.Seo:XmlSitemap) < prototype(Neos.Fusion:Http.Message) {
             </urlset>
         `
 
-        @cache.entryTags {
-            1 = ${Neos.Caching.nodeTag(this.startingPoint)}
-            2 = ${Neos.Caching.descendantOfTag(this.startingPoint)}
+        @context.startingPoint = ${this.startingPoint}        
+        @cache {
+            mode = 'cached'
+            entryIdentifier {
+                startingPoint = ${startingPoint}
+            }
+            entryTags {
+                1 = ${Neos.Caching.nodeTag(startingPoint)}
+                2 = ${Neos.Caching.descendantOfTag(startingPoint)}
+            }
         }
     }
 }


### PR DESCRIPTION
The xml-sitemap  did have cache-tags but no cache-mode and cache-identifier. 
Since the default cache mode is embed the sitemap cache was embedded into the document 
cache for the document and thus only updated when the siteNode was changed.

This change adds the cache-identifier and the cache-mode. It also puts the startingPoint into the context as somehow it was not available in the entry identifier otherwise.

resolves: #141