### PR TITLE
BUGFIX: Prevent errors with invalid charactes in image sitemap

### DIFF
--- a/Resources/Private/Fusion/XmlSitemap/XmlSitemapImageUrls.fusion
+++ b/Resources/Private/Fusion/XmlSitemap/XmlSitemapImageUrls.fusion
@@ -4,10 +4,33 @@ prototype(Neos.Seo:XmlSitemap.ImageUrls) < prototype(Neos.Fusion:Component) {
     renderer = afx`
         <Neos.Fusion:Loop items={props.images} itemName="image">
             <Neos.Fusion:Tag tagName="image:image">
-                <Neos.Fusion:Tag @key="loc" tagName="image:loc"><Neos.Neos:ImageUri asset={image}/></Neos.Fusion:Tag>
-                <Neos.Fusion:Tag @key="title" tagName="image:title" @if.hasTitle={image.title}>{image.title}</Neos.Fusion:Tag>
-                <Neos.Fusion:Tag @key="license" tagName="image:license" @if.hasLicense={image.copyrightNotice}>{image.copyrightNotice}</Neos.Fusion:Tag>
-                <Neos.Fusion:Tag @key="caption" tagName="image:caption" @if.hasCaption={image.caption}>{image.caption}</Neos.Fusion:Tag>
+                <Neos.Fusion:Tag @key="loc" tagName="image:loc">
+                    <Neos.Neos:ImageUri asset={image}/>
+                </Neos.Fusion:Tag>
+                <Neos.Fusion:Tag
+                    @key="title"
+                    tagName="image:title"
+                    content.@process.wrap={'<![CDATA[' + value + ']]>'}
+                    @if.hasTitle={image.title}
+                >
+                    {image.title}
+                </Neos.Fusion:Tag>
+                <Neos.Fusion:Tag
+                    @key="license"
+                    tagName="image:license"
+                    content.@process.wrap={'<![CDATA[' + value + ']]>'}
+                    @if.hasLicense={image.copyrightNotice}
+                >
+                    {image.copyrightNotice}
+                </Neos.Fusion:Tag>
+                <Neos.Fusion:Tag
+                    @key="caption"
+                    tagName="image:caption"
+                    content.@process.wrap={'<![CDATA[' + value + ']]>'}
+                    @if.hasCaption={image.caption}
+                >
+                    {image.caption}
+                </Neos.Fusion:Tag>
             </Neos.Fusion:Tag>
         </Neos.Fusion:Loop>
     `


### PR DESCRIPTION
Having special characters in an image title/caption/copyright notice broke the sitemap