### PR TITLE
Task: Allow 160 chars on metaDescription

### DIFF
--- a/Configuration/NodeTypes.Mixin.SeoMetaTags.yaml
+++ b/Configuration/NodeTypes.Mixin.SeoMetaTags.yaml
@@ -24,7 +24,7 @@
             placeholder: i18n
       validation:
         'Neos.Neos/Validation/StringLengthValidator':
-          maximum: 156
+          maximum: 160
     metaKeywords:
       type: string
       ui:


### PR DESCRIPTION
According to https://www.sistrix.de/frag-sistrix/onpage-optimierung/meta-element-meta-tag/wie-sieht-die-optimale-meta-description-aus/, we can use up to 160 chars within the meta description. 

So we should allow the 4 more chars to the user 😉 