### PR TITLE
BUGFIX: Language fallback handling for canonical and alternate language links

### DIFF
--- a/Resources/Private/Fusion/Metadata/AlternateLanguageLink.fusion
+++ b/Resources/Private/Fusion/Metadata/AlternateLanguageLink.fusion
@@ -17,4 +17,6 @@ prototype(Neos.Seo:AlternateLanguageLink) < prototype(Neos.Fusion:Component) {
     renderer = afx`<link rel="alternate" hreflang={props.hreflang} href={props.nodeUri}/>`
 
     @if.hasNode = ${this.node}
+    @if.hasMetaRobotsNoIndexNotSet = ${!q(this.node).property('metaRobotsNoindex') && !q(this.node).is('[instanceof Neos.Seo:NoindexMixin]')}
+    @if.hasNoForeignCanonical = ${String.isBlank(q(this.node).property('canonicalLink'))}
 }

--- a/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
+++ b/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
@@ -22,6 +22,7 @@ prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Fusion:Component) {
                 @if.isDefaultLocale={props.defaultLocale == item.dimensions[props.dimension][0]}/>
             <Neos.Seo:AlternateLanguageLink node={item.node}
                 @if.isNotAbsent={item.state != 'absent'}
+                @if.existsInTargetDimensions={item.node.dimensions == item.node.context.targetDimensionValues}
                 @if.notExcluded={!props.excludedPresets || Array.indexOf(props.excludedPresets, item.dimensions[props.dimension][0]) == -1}
                 hreflang={String.replace((item.preset ? item.preset.values[0] : item.dimensions[props.dimension][0]), props.dimensionValueSeparator, '-')}/>
         `

--- a/Resources/Private/Fusion/Metadata/CanonicalLink.fusion
+++ b/Resources/Private/Fusion/Metadata/CanonicalLink.fusion
@@ -3,7 +3,17 @@ prototype(Neos.Seo:CanonicalLink) < prototype(Neos.Fusion:Tag) {
     attributes {
         rel = 'canonical'
         href = Neos.Fusion:Component {
-            node = ${documentNode}
+            node = Neos.Fusion:Case {
+                useFallback {
+                    condition = ${node.dimensions != node.context.targetDimensionValues}
+                    targetDimensions = ${Array.map(node.dimensions, (item) => item[0])}
+                    renderer = ${q(node).context({dimensions: node.dimensions, targetDimensions: this.targetDimensions}).get(0)}
+                }
+                default {
+                    condition = true
+                    renderer = ${node}
+                }
+            }
             canonicalLink = ${q(this.node).property('canonicalLink')}
 
             renderer = Neos.Fusion:Case {

--- a/Resources/Private/Fusion/Metadata/LangAttribute.fusion
+++ b/Resources/Private/Fusion/Metadata/LangAttribute.fusion
@@ -1,5 +1,5 @@
 prototype(Neos.Seo:LangAttribute) < prototype(Neos.Fusion:Value) {
-    value = ${String.replace(documentNode.context.dimensions.language[0], '_', '-')}
+    value = ${String.replace(documentNode.dimensions.language[0], '_', '-')}
     @if.languageDimensionExists = ${Configuration.setting('Neos.ContentRepository.contentDimensions.language') != null}
     @if.onlyRenderWhenInLiveWorkspace = ${node.context.workspace.name == 'live'}
 }


### PR DESCRIPTION
The canonical link will now link to the original node if a dimension fallback is active.

The list of alternate language links will not contain nodes anymore if they don't exist in the target language.

Also the `lang` attribute of the html tag is now correct when a fallback is shown.

All three issues can be tested by browsing to `/uk` in the Neos.Demo.
`lang` should be `en_US`, canonical should link to it to and no alternate language link for uk should exist.