### PR TITLE
BUGFIX: Change meta description placeholder

### DIFF
--- a/Resources/Private/Translations/af/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/af/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="needs-translation">Description</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="needs-translation">max. 156 characters</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="needs-translation">max. 160 characters</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="needs-translation">Keywords</target></trans-unit>

--- a/Resources/Private/Translations/ar/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/ar/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="translated">الوصف</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">الحد الأقصى 156 حرف</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">الحد الأقصى 160 حرف</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="translated">كلمات مفتاحية</target></trans-unit>

--- a/Resources/Private/Translations/ca/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/ca/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="needs-translation">Description</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">màx. 156 caràcters</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">màx. 160 caràcters</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="needs-translation">Keywords</target></trans-unit>

--- a/Resources/Private/Translations/cs/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/cs/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="translated">Popis</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">max. 156 znaků</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">max. 160 znaků</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="translated">Klíčová slova</target></trans-unit>

--- a/Resources/Private/Translations/da/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/da/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="final">Beskrivelse</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve" approved="yes">
-				<source>max. 156 characters</source>
-			<target state="final">maks. 156 tegn</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="final">maks. 160 tegn</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve" approved="yes">
 				<source>Keywords</source>
 			<target state="final">Nøgleord</target></trans-unit>

--- a/Resources/Private/Translations/de/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="final">Beschreibung</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve" approved="yes">
-				<source>max. 156 characters</source>
-			<target state="final">max. 156 Zeichen</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="final">max. 160 Zeichen</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve" approved="yes">
 				<source>Keywords</source>
 			<target state="final">Keywords</target></trans-unit>

--- a/Resources/Private/Translations/el/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/el/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="needs-translation">Description</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="needs-translation">max. 156 characters</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="needs-translation">max. 160 characters</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="needs-translation">Keywords</target></trans-unit>

--- a/Resources/Private/Translations/en/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,7 +9,7 @@
 				<source>Description</source>
 			</trans-unit>
 			<trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
+				<source>max. 160 characters</source>
 			</trans-unit>
 			<trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>

--- a/Resources/Private/Translations/es/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/es/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="final">Descripción</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve" approved="yes">
-				<source>max. 156 characters</source>
-			<target state="final">máx. 156 caracteres</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="final">máx. 160 caracteres</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="translated">Palabras clave</target></trans-unit>

--- a/Resources/Private/Translations/fi/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/fi/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="final">Kuvaus</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve" approved="yes">
-				<source>max. 156 characters</source>
-			<target state="final">enintään 156 merkkiä</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="final">enintään 160 merkkiä</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve" approved="yes">
 				<source>Keywords</source>
 			<target state="final">Avainsanat</target></trans-unit>

--- a/Resources/Private/Translations/fr/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/fr/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="final">Description</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">max. 156 caractères</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">max. 160 caractères</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve" approved="yes">
 				<source>Keywords</source>
 			<target state="final">Mots-clés</target></trans-unit>

--- a/Resources/Private/Translations/he/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/he/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="needs-translation">Description</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">מקסימום, 156 תווים</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">מקסימום, 160 תווים</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="needs-translation">Keywords</target></trans-unit>

--- a/Resources/Private/Translations/hu/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/hu/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="translated">Leírás</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">maximum 156 karakter</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">maximum 160 karakter</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="translated">Kulcsszavak</target></trans-unit>

--- a/Resources/Private/Translations/hy_AM/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/hy_AM/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="needs-translation">Description</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="needs-translation">max. 156 characters</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="needs-translation">max. 160 characters</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="needs-translation">Keywords</target></trans-unit>

--- a/Resources/Private/Translations/id_ID/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/id_ID/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="translated">Deskripsi</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve" approved="yes">
-				<source>max. 156 characters</source>
-			<target state="final">max. 156 karakter</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="final">max. 160 karakter</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="translated">Kata kunci</target></trans-unit>

--- a/Resources/Private/Translations/it/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/it/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="translated">Descrizione</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">max. 156 caratteri</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">max. 160 caratteri</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="translated">Parole chiave</target></trans-unit>

--- a/Resources/Private/Translations/ja/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/ja/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="translated">概要</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">最大。156 文字</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">最大。160 文字</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="translated">キーワード</target></trans-unit>

--- a/Resources/Private/Translations/kk_KZ/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/kk_KZ/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="needs-translation">Description</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="needs-translation">max. 156 characters</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="needs-translation">max. 160 characters</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="needs-translation">Keywords</target></trans-unit>

--- a/Resources/Private/Translations/km/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/km/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,7 +9,7 @@
 				<source>Description</source>
 			<target state="final">ពិពណ៍នា</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve" approved="yes">
-				<source>max. 156 characters</source>
+				<source>max. 160 characters</source>
 			<target state="final">អតិបរមា​ ១៥០ តួអក្សរ</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve" approved="yes">
 				<source>Keywords</source>

--- a/Resources/Private/Translations/ko/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/ko/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="needs-translation">Description</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">최대 156 글자</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">최대 160 글자</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="needs-translation">Keywords</target></trans-unit>

--- a/Resources/Private/Translations/la/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/la/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,7 +9,7 @@
 				<source>Description</source>
 			<target xml:lang="la-LA">crwdns6440:0crwdne6440:0</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
+				<source>max. 160 characters</source>
 			<target xml:lang="la-LA">crwdns6441:0crwdne6441:0</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>

--- a/Resources/Private/Translations/lv/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/lv/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="final">Apraksts</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">maks. 156 rakstzīmes</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">maks. 160 rakstzīmes</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve" approved="yes">
 				<source>Keywords</source>
 			<target state="final">Atslēgas vārdi</target></trans-unit>

--- a/Resources/Private/Translations/mr/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/mr/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="needs-translation">Description</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="needs-translation">max. 156 characters</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="needs-translation">max. 160 characters</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="needs-translation">Keywords</target></trans-unit>

--- a/Resources/Private/Translations/nl/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/nl/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="final">Omschrijving</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">max. 156 tekens</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">max. 160 tekens</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve" approved="yes">
 				<source>Keywords</source>
 			<target state="final">Trefwoorden</target></trans-unit>

--- a/Resources/Private/Translations/no/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/no/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="translated">Beskrivelse</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="needs-translation">max. 156 characters</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="needs-translation">max. 160 characters</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="translated">Nøkkelord</target></trans-unit>

--- a/Resources/Private/Translations/pl/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/pl/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="final">Opis</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve" approved="yes">
-				<source>max. 156 characters</source>
-			<target state="final">maks. 156 znaków</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="final">maks. 160 znaków</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve" approved="yes">
 				<source>Keywords</source>
 			<target state="final">Słowa kluczowe</target></trans-unit>

--- a/Resources/Private/Translations/ps/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/ps/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="needs-translation">Description</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="needs-translation">max. 156 characters</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="needs-translation">max. 160 characters</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="needs-translation">Keywords</target></trans-unit>

--- a/Resources/Private/Translations/pt/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/pt/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="needs-translation">Description</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">max. 156 carateres</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">max. 160 carateres</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="needs-translation">Keywords</target></trans-unit>

--- a/Resources/Private/Translations/pt_BR/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/pt_BR/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="translated">Descrição</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">máximo de 156 caracteres</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">máximo de 160 caracteres</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="translated">Palavras-Chave</target></trans-unit>

--- a/Resources/Private/Translations/ro/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/ro/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="translated">Descriere (meta description)</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">maxim 156 caractere</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">maxim 160 caractere</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="translated">Cuvinte cheie (keywords)</target></trans-unit>

--- a/Resources/Private/Translations/ru/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/ru/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="final">Описание</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve" approved="yes">
-				<source>max. 156 characters</source>
-			<target state="final">макс. 156 символов</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="final">макс. 160 символов</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve" approved="yes">
 				<source>Keywords</source>
 			<target state="final">Ключевые слова</target></trans-unit>

--- a/Resources/Private/Translations/sr/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/sr/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="needs-translation">Description</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="needs-translation">max. 156 characters</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="needs-translation">max. 160 characters</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="needs-translation">Keywords</target></trans-unit>

--- a/Resources/Private/Translations/sv/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/sv/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="translated">Beskrivning</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">max 156 tecken</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">max 160 tecken</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="translated">Sökord</target></trans-unit>

--- a/Resources/Private/Translations/tl_PH/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/tl_PH/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="needs-translation">Description</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">max. 156 na mga karakter</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">max. 160 na mga karakter</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="needs-translation">Keywords</target></trans-unit>

--- a/Resources/Private/Translations/tr/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/tr/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="translated">Açıklama</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">maks. 156 karakter kullanabilirsiniz</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">maks. 160 karakter kullanabilirsiniz</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="translated">Anahtar Kelimeleriniz</target></trans-unit>

--- a/Resources/Private/Translations/uk/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/uk/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="translated">Опис</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">макс. 156 символів</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">макс. 160 символів</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="translated">Ключові слова</target></trans-unit>

--- a/Resources/Private/Translations/vi/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/vi/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="translated">Mô tả</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">max. 156 characters</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">max. 160 characters</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="translated">Từ khóa</target></trans-unit>

--- a/Resources/Private/Translations/zh/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/zh/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="translated">说明</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">最多 156 字符</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">最多 160 字符</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="translated">关键字</target></trans-unit>

--- a/Resources/Private/Translations/zh_TW/NodeTypes/SeoMetaTagsMixin.xlf
+++ b/Resources/Private/Translations/zh_TW/NodeTypes/SeoMetaTagsMixin.xlf
@@ -9,8 +9,8 @@
 				<source>Description</source>
 			<target state="translated">描述</target></trans-unit>
       <trans-unit id="properties.metaDescription.textAreaEditor.placeholder" xml:space="preserve">
-				<source>max. 156 characters</source>
-			<target state="translated">最大 156字元</target></trans-unit>
+				<source>max. 160 characters</source>
+			<target state="translated">最大 160字元</target></trans-unit>
       <trans-unit id="properties.metaKeywords" xml:space="preserve">
 				<source>Keywords</source>
 			<target state="translated">關鍵字</target></trans-unit>


### PR DESCRIPTION
Adjust the placeholder for the meta description to the current max character value from the configuration.

Fixes: #157 
