### PR TITLE
TASK: Add google-site-verification meta tag

### DIFF
--- a/Configuration/NodeTypes.Mixin.GoogleSiteVerification.yaml
+++ b/Configuration/NodeTypes.Mixin.GoogleSiteVerification.yaml
@@ -1,0 +1,15 @@
+'Neos.Seo:GoogleSiteVerificationMixin':
+  abstract: true
+  properties:
+    metaGoogleSiteVerification:
+      type: string
+      ui:
+        label: i18n
+        help:
+          message: i18n
+        inspector:
+          group: 'seometa'
+          position: 100
+      validation:
+        'Neos.Neos/Validation/RegularExpressionValidator':
+          regularExpression: '/^[a-z0-9]$/i'

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -137,8 +137,28 @@ You can activate and configure them according to your needs.
 The prototypes are also meant to be a very basic standard for your own structured elements.
 So feel free to adjust and reuse them.
 
+
+Google Search Console
+^^^^^^^^^^^^^^^^^^^^^
+
 When you activate structured data elements and have them on your live site you should use the Google Search Console
 to verify that they work as expected: https://search.google.com/search-console.
+
+You can verify site ownership for the Google Search Console with the following setting:
+
+  Neos:
+    Seo:
+      google:
+        siteVerification: 'yourVerificationProperty'
+
+Or if you prefer having a property to edit in the Neos backend (or on multi site setups), add the following nodeType to the nodeType definition of your site node:
+
+  'Vendor.Package:Document.Home':
+    superTypes:
+      'Neos.Seo:GoogleSiteVerificationMixin': true
+
+Both options will add a meta tag required for Google to verify the ownership.
+
 
 Breadcrumb
 ^^^^^^^^^^

--- a/Resources/Private/Fusion/Metadata/GoogleSiteVerification.fusion
+++ b/Resources/Private/Fusion/Metadata/GoogleSiteVerification.fusion
@@ -1,0 +1,13 @@
+prototype(Neos.Seo:GoogleSiteVerification) < prototype(Neos.Fusion:Component) {
+    googleSiteVerification = ${q(node).property('metaGoogleSiteVerification') || Configuration.setting('Neos.Seo.google.siteVerification')}
+
+    @if.isSite = ${node == site}
+    @if.hasGoogleSiteVerification = ${this.googleSiteVerification}
+
+    renderer = afx`
+        <meta
+            property="google-site-verification"
+            content={props.googleSiteVerification}
+        />
+    `
+}

--- a/Resources/Private/Fusion/Page.fusion
+++ b/Resources/Private/Fusion/Page.fusion
@@ -11,6 +11,7 @@ prototype(Neos.Neos:Page) {
         twitterCard = Neos.Seo:TwitterCard
         openGraphMetaTags = Neos.Seo:OpenGraphMetaTags
         facebookMetaTags = Neos.Seo:FacebookMetaTags
+        metaGoogleSiteVerification = Neos.Seo:GoogleSiteVerification
         structuredData = Neos.Seo:StructuredData.Container
     }
 }

--- a/Resources/Private/Translations/de/NodeTypes/GoogleSiteVerificationMixin.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/GoogleSiteVerificationMixin.xlf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Seo" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+			<trans-unit id="properties.metaGoogleSiteVerification" xml:space="preserve" approved="yes">
+				<source>Google Site Verification property</source>
+			    <target state="final">Google Site Verification Property</target>
+			</trans-unit>
+			<trans-unit id="properties.metaGoogleSiteVerification.ui.help.message" xml:space="preserve">
+				<source>This sets the HTML tag to confirm site ownership for Google Search Console. Enter only the value here, not the complete tag.</source>
+				<target state="final">Hierdurch wird der HTML-Tag zur Bestätigung der Inhaberschaft für die Google Search Console gesetzt. Tragen Sie hier nur den Wert ein, nicht den kompletten Tag.</target>
+			</trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/en/NodeTypes/GoogleSiteVerificationMixin.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/GoogleSiteVerificationMixin.xlf
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file original="" product-name="Neos.Seo" source-language="en" datatype="plaintext">
+		<body>
+			<trans-unit id="properties.metaGoogleSiteVerification" xml:space="preserve">
+				<source>Google Site Verification property</source>
+			</trans-unit>
+			<trans-unit id="properties.metaGoogleSiteVerification.ui.help.message" xml:space="preserve">
+				<source>This sets the HTML tag to confirm site ownership for Google Search Console. Enter only the value here, not the complete tag.</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>


### PR DESCRIPTION
When using the google search console to have a better overview about search results of your site, till now you had to add the required meta tag (or verification file or header) yourself for each project. 

This pull request adds a property to the seo tags so you can easily add your google-site-verification meta tag. Output will be 

```html
<meta name="google-site-verification" content="yourGoogleSiteVerificationProperty" />
```