### PR TITLE
BUGFIX: add missing editors to nodetypes for showing backend translations

### DIFF
--- a/Configuration/NodeTypes.Mixin.TwitterCard.yaml
+++ b/Configuration/NodeTypes.Mixin.TwitterCard.yaml
@@ -35,6 +35,7 @@
         label: i18n
         inspector:
           group: 'twittercard'
+          editor: 'Neos.Neos/Inspector/Editors/TextFieldEditor'
           editorOptions:
             placeholder: i18n
       validation:

--- a/Configuration/NodeTypes.Mixin.XmlSitemap.yaml
+++ b/Configuration/NodeTypes.Mixin.XmlSitemap.yaml
@@ -22,7 +22,7 @@
           editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
           editorOptions:
             allowEmpty: true
-            placeholder: 'none (unspecified)'
+            placeholder: i18n
             values:
               always:
                 label: i18n
@@ -52,6 +52,7 @@
         inspector:
           group: 'xmlsitemap'
           position: 20
+          editor: 'Neos.Neos/Inspector/Editors/TextFieldEditor'
           editorOptions:
             placeholder: i18n
       validation:


### PR DESCRIPTION
Resolves #166 