### PR TITLE
BUGFIX: Adjust installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Check the [documentation](https://neos-seo.readthedocs.io/en/stable/) for all fe
 
 1. Run the following command f.e. in your site package:
    ```bash
-   composer require --no-update neos/seo
+   composer require --no-update "neos/seo:^3.3"
    ```
    
 2. Update your dependencies by running the following command in your project root folder:


### PR DESCRIPTION
Neos.Seo 4.0 is for the upcoming Neos 9 release, so this small change helps integrators to start with the right version.

Close #169