### PR TITLE
9.0: FEATURE: Improve ESCR Compatibility - Part 1

### DIFF
--- a/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
+++ b/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
@@ -1,12 +1,11 @@
 prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Fusion:Component) {
-    @if.languageDimensionExists = ${this.dimensionConfiguration != null}
     @if.onlyRenderWhenInLiveWorkspace = ${Neos.Node.isLive(this.node)}
+    @if.languageDimensionExists = ${this.defaultDimensionValue}
     @if.hasNoForeignCanonical = ${String.isBlank(q(this.node).property('canonicalLink'))}
 
     node = ${documentNode}
     dimension = 'language'
-    defaultLocale = ${Configuration.setting('Neos.ContentRepository.contentDimensions.' + this.dimension + '.default')}
-    dimensionConfiguration = ${Configuration.setting('Neos.ContentRepository.contentDimensions.' + this.dimension)}
+    defaultDimensionValue = ${Neos.Dimension.findDefaultValue(this.node, this.dimension)}
     excludedPresets = ${[]}
 
     # The hreflang value needs to have a format like 'en-US', therefore internally used values
@@ -14,16 +13,23 @@ prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Fusion:Component) {
     dimensionValueSeparator = '_'
 
     renderer = Neos.Fusion:Loop {
-        items = Neos.Neos:DimensionsMenuItems {
-            dimension = ${props.dimension}
+        items = ${Neos.Dimension.findVariantsInDimension(props.node, props.dimension)}
+        itemName = 'alternateLanguageNode'
+        itemRenderer = Neos.Fusion:Component {
+            @if.indexingAllowed = ${q(alternateLanguageNode).property('metaRobotsNoindex') != true}
+            @if.notExcluded = ${!props.excludedPresets || Array.indexOf(props.excludedPresets, this.dimensionValue) == -1}
+
+            node = ${alternateLanguageNode}
+            dimensionValue = ${Neos.Dimension.currentValue(alternateLanguageNode, props.dimension)}
+            defaultDimensionValue = ${props.defaultDimensionValue}
+            dimensionValueSeparator = ${props.dimensionValueSeparator}
+
+            renderer = afx`
+                <Neos.Seo:AlternateLanguageLink @key="defaultLink" node={props.node} hreflang="x-default"
+                    @if.isDefaultLocale={props.defaultDimensionValue == props.dimensionValue}/>
+                <Neos.Seo:AlternateLanguageLink node={props.node}
+                    hreflang={String.replace(props.dimensionValue, props.dimensionValueSeparator, '-')}/>
+            `
         }
-        itemRenderer = afx`
-            <Neos.Seo:AlternateLanguageLink @key="defaultLink" node={item.node} hreflang="x-default"
-                @if.isDefaultLocale={props.defaultLocale == item.dimensions[props.dimension][0]}/>
-            <Neos.Seo:AlternateLanguageLink node={item.node}
-                @if.isNotAbsent={item.state != 'absent'}
-                @if.notExcluded={!props.excludedPresets || Array.indexOf(props.excludedPresets, item.dimensions[props.dimension][0]) == -1}
-                hreflang={String.replace((item.preset ? item.preset.values[0] : item.dimensions[props.dimension][0]), props.dimensionValueSeparator, '-')}/>
-        `
     }
 }

--- a/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
+++ b/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
@@ -13,7 +13,7 @@ prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Fusion:Component) {
     dimensionValueSeparator = '_'
 
     renderer = Neos.Fusion:Loop {
-        items = ${props.languageDimension.values.values}
+        items = ${Neos.Dimension.allDimensionValues(site, 'language')}
         itemName = 'dimensionValue'
         # First root value is used as default language
         iterationName = 'iteration'

--- a/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
+++ b/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
@@ -1,6 +1,6 @@
 prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Fusion:Component) {
     @if.languageDimensionExists = ${this.dimensionConfiguration != null}
-    @if.onlyRenderWhenInLiveWorkspace = ${this.node.context.workspace.name == 'live'}
+    @if.onlyRenderWhenInLiveWorkspace = ${Neos.Node.isLive(this.node)}
     @if.hasNoForeignCanonical = ${String.isBlank(q(this.node).property('canonicalLink'))}
 
     node = ${documentNode}

--- a/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
+++ b/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
@@ -1,11 +1,10 @@
 prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Fusion:Component) {
     @if.onlyRenderWhenInLiveWorkspace = ${Neos.Node.isLive(this.node)}
-    @if.languageDimensionExists = ${this.languageDimension}
+    @if.languageDimensionExists = ${this.dimension}
     @if.hasNoForeignCanonical = ${String.isBlank(q(this.node).property('canonicalLink'))}
 
     node = ${documentNode}
     dimension = 'language'
-    languageDimension = ${Neos.Dimension.all(this.node)[this.dimension]}
     excludedPresets = ${[]}
 
     # The hreflang value needs to have a format like 'en-US', therefore internally used values
@@ -13,7 +12,7 @@ prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Fusion:Component) {
     dimensionValueSeparator = '_'
 
     renderer = Neos.Fusion:Loop {
-        items = ${Neos.Dimension.allDimensionValues(site, 'language')}
+        items = ${Neos.Dimension.allDimensionValues(site, props.dimension)}
         itemName = 'dimensionValue'
         # First root value is used as default language
         iterationName = 'iteration'

--- a/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
+++ b/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
@@ -1,11 +1,11 @@
 prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Fusion:Component) {
     @if.onlyRenderWhenInLiveWorkspace = ${Neos.Node.isLive(this.node)}
-    @if.languageDimensionExists = ${this.defaultDimensionValue}
+    @if.languageDimensionExists = ${this.languageDimension}
     @if.hasNoForeignCanonical = ${String.isBlank(q(this.node).property('canonicalLink'))}
 
     node = ${documentNode}
     dimension = 'language'
-    defaultDimensionValue = ${Neos.Dimension.findDefaultValue(this.node, this.dimension)}
+    languageDimension = ${Neos.Dimension.all(this.node)[this.dimension]}
     excludedPresets = ${[]}
 
     # The hreflang value needs to have a format like 'en-US', therefore internally used values
@@ -13,22 +13,23 @@ prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Fusion:Component) {
     dimensionValueSeparator = '_'
 
     renderer = Neos.Fusion:Loop {
-        items = ${Neos.Dimension.findVariantsInDimension(props.node, props.dimension)}
-        itemName = 'alternateLanguageNode'
+        items = ${props.languageDimension.values.values}
+        itemName = 'dimensionValue'
+        # First root value is used as default language
+        iterationName = 'iteration'
         itemRenderer = Neos.Fusion:Component {
-            @if.indexingAllowed = ${q(alternateLanguageNode).property('metaRobotsNoindex') != true}
-            @if.notExcluded = ${!props.excludedPresets || Array.indexOf(props.excludedPresets, this.dimensionValue) == -1}
+            @if.variantExists = ${this.node}
+            @if.indexingAllowed = ${q(this.node).property('metaRobotsNoindex') != true}
+            @if.notExcluded = ${!props.excludedPresets || Array.indexOf(props.excludedPresets, dimensionValue.value) == -1}
 
-            node = ${alternateLanguageNode}
-            dimensionValue = ${Neos.Dimension.currentValue(alternateLanguageNode, props.dimension)}
-            defaultDimensionValue = ${props.defaultDimensionValue}
+            node = ${Neos.Dimension.findVariantInDimension(props.node, props.dimension, dimensionValue)}
             dimensionValueSeparator = ${props.dimensionValueSeparator}
 
             renderer = afx`
                 <Neos.Seo:AlternateLanguageLink @key="defaultLink" node={props.node} hreflang="x-default"
-                    @if.isDefaultLocale={props.defaultDimensionValue == props.dimensionValue}/>
+                                                @if.isFirst={iteration.isFirst}/>
                 <Neos.Seo:AlternateLanguageLink node={props.node}
-                    hreflang={String.replace(props.dimensionValue, props.dimensionValueSeparator, '-')}/>
+                    hreflang={String.replace(dimensionValue.value, props.dimensionValueSeparator, '-')}/>
             `
         }
     }

--- a/Resources/Private/Fusion/Metadata/LangAttribute.fusion
+++ b/Resources/Private/Fusion/Metadata/LangAttribute.fusion
@@ -1,5 +1,9 @@
 prototype(Neos.Seo:LangAttribute) < prototype(Neos.Fusion:Value) {
-    value = ${String.replace(documentNode.subgraphIdentity.dimensionSpacePoint.coordinates.language, '_', '-')}
-    @if.languageDimensionExists = ${documentNode.subgraphIdentity.dimensionSpacePoint.coordinates.language}
+    dimension = 'language'
+    dimensionValueSeparator = '_'
+
+    value = ${Neos.Dimension.currentValue(documentNode, this.dimension)}
+    value.@process.replaceUnderscore = ${value ? String.replace(value, this.dimensionValueSeparator , '-') : null}
+
     @if.onlyRenderWhenInLiveWorkspace = ${Neos.Node.isLive(documentNode)}
 }

--- a/Resources/Private/Fusion/Metadata/LangAttribute.fusion
+++ b/Resources/Private/Fusion/Metadata/LangAttribute.fusion
@@ -1,5 +1,5 @@
 prototype(Neos.Seo:LangAttribute) < prototype(Neos.Fusion:Value) {
-    value = ${String.replace(documentNode.context.dimensions.language[0], '_', '-')}
-    @if.languageDimensionExists = ${Configuration.setting('Neos.ContentRepository.contentDimensions.language') != null}
-    @if.onlyRenderWhenInLiveWorkspace = ${node.context.workspace.name == 'live'}
+    value = ${String.replace(documentNode.subgraphIdentity.dimensionSpacePoint.coordinates.language, '_', '-')}
+    @if.languageDimensionExists = ${documentNode.subgraphIdentity.dimensionSpacePoint.coordinates.language}
+    @if.onlyRenderWhenInLiveWorkspace = ${Neos.Node.isLive(documentNode)}
 }

--- a/Resources/Private/Fusion/Metadata/LangAttribute.fusion
+++ b/Resources/Private/Fusion/Metadata/LangAttribute.fusion
@@ -2,7 +2,7 @@ prototype(Neos.Seo:LangAttribute) < prototype(Neos.Fusion:Value) {
     dimension = 'language'
     dimensionValueSeparator = '_'
 
-    value = ${Neos.Dimension.currentValue(documentNode, this.dimension)}
+    value = ${Neos.Dimension.currentValue(documentNode, this.dimension).value}
     value.@process.replaceUnderscore = ${value ? String.replace(value, this.dimensionValueSeparator , '-') : null}
 
     @if.onlyRenderWhenInLiveWorkspace = ${Neos.Node.isLive(documentNode)}

--- a/Resources/Private/Fusion/Metadata/TitleTag.fusion
+++ b/Resources/Private/Fusion/Metadata/TitleTag.fusion
@@ -1,5 +1,5 @@
 prototype(Neos.Seo:TitleTag) < prototype(Neos.Fusion:Component) {
-    suffix = ${site.context.currentSite.name}
+    suffix = ${Neos.Site.findBySiteNode(site).name}
     titleOverride = ${q(node).property('titleOverride')}
     breadcrumbSeparator = ' - '
     suffixSeparator = ${this.breadcrumbSeparator}


### PR DESCRIPTION
- Use `Neos.Node.isLive(...)` instead of `this.node.context.workspace.name == 'live'`
- Update `Neos.Seo:LangAttribute.fusion` to get correct language based on new node properties
- Use new `Neos.Dimension` helper for `AlternateLanguageLinks`

Tested features:

- TitleTag
- MetaRobots, MetaKeyword, MetaDescription
- Lang attribute at HTML tag
- Canonical and alternative links
- Social meta data

Relates: #171 
Relates: neos/neos-development-collection#4074
Relates: neos/neos-development-collection#4085
