### PR TITLE
Adjust to changed CR NodeType fallback handling

### DIFF
--- a/Classes/Fusion/Helper/ImageHelper.php
+++ b/Classes/Fusion/Helper/ImageHelper.php
@@ -21,11 +21,8 @@ use Neos\Media\Exception\ThumbnailServiceException;
 
 class ImageHelper implements ProtectedContextAwareInterface
 {
-    /**
-     * @Flow\Inject
-     * @var ThumbnailService
-     */
-    protected $thumbnailService;
+    #[Flow\Inject]
+    protected ThumbnailService $thumbnailService;
 
     /**
      * @param AssetInterface $asset
@@ -54,8 +51,7 @@ class ImageHelper implements ProtectedContextAwareInterface
         $async = false,
         $quality = null,
         $format = null
-    )
-    {
+    ): ?ImageInterface {
         if (!empty($preset)) {
             $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($preset);
         } else {
@@ -82,9 +78,8 @@ class ImageHelper implements ProtectedContextAwareInterface
      * All methods are considered safe
      *
      * @param string $methodName
-     * @return boolean
      */
-    public function allowsCallOfMethod($methodName)
+    public function allowsCallOfMethod($methodName): bool
     {
         return true;
     }

--- a/Classes/Fusion/XmlSitemapUrlsImplementation.php
+++ b/Classes/Fusion/XmlSitemapUrlsImplementation.php
@@ -19,6 +19,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindSubtreeFilter
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeTypeConstraints;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Subtree;
+use Neos\ContentRepositoryRegistry\Utility\ContentRepositoryRegistryProvider;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Fusion\FusionObjects\AbstractFusionObject;
@@ -28,6 +29,7 @@ use Neos\Utility\Exception\PropertyNotAccessibleException;
 
 class XmlSitemapUrlsImplementation extends AbstractFusionObject
 {
+    use ContentRepositoryRegistryProvider;
     use NodeTypeWithFallbackProvider;
 
     /**

--- a/Classes/Fusion/XmlSitemapUrlsImplementation.php
+++ b/Classes/Fusion/XmlSitemapUrlsImplementation.php
@@ -19,17 +19,16 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindSubtreeFilter
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeTypeConstraints;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Subtree;
-use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Fusion\FusionObjects\AbstractFusionObject;
 use Neos\Media\Domain\Model\ImageInterface;
+use Neos\Neos\Utility\NodeTypeWithFallbackProvider;
 use Neos\Utility\Exception\PropertyNotAccessibleException;
 
 class XmlSitemapUrlsImplementation extends AbstractFusionObject
 {
-    #[Flow\Inject(lazy: false)]
-    protected ContentRepositoryRegistry $contentRepositoryRegistry;
+    use NodeTypeWithFallbackProvider;
 
     /**
      * @var PersistenceManager
@@ -205,7 +204,7 @@ class XmlSitemapUrlsImplementation extends AbstractFusionObject
     protected function resolveImages(Subtree $subtree, array &$item): void
     {
         $node = $subtree->node;
-        $assetPropertiesForNodeType = $this->getAssetPropertiesForNodeType($node->nodeType);
+        $assetPropertiesForNodeType = $this->getAssetPropertiesForNodeType($this->getNodeType($node));
 
         foreach ($assetPropertiesForNodeType as $propertyName) {
             if (is_array($node->getProperty($propertyName)) && !empty($node->getProperty($propertyName))) {
@@ -230,7 +229,7 @@ class XmlSitemapUrlsImplementation extends AbstractFusionObject
      */
     protected function isDocumentNodeToBeIndexed(Node $node): bool
     {
-        return !$node->nodeType->isOfType('Neos.Seo:NoindexMixin')
+        return !$this->getNodeType($node)->isOfType('Neos.Seo:NoindexMixin')
             && ($this->getRenderHiddenInIndex() || $node->getProperty('hiddenInIndex') !== true)
             && $node->getProperty('metaRobotsNoindex') !== true
             && (


### PR DESCRIPTION
This adjusts NodeType fallback handling to the latest CR changes.

Background: The NodeTypeManager no longer does fallback handling but throws an exception instead. The fallback handling mechanism has been moved to Neos.Neos, which provides a utility trait to deal with this.

Should be merged AFTER https://github.com/neos/neos-development-collection/pull/4466
