### PR TITLE
TASK: Use `!renderingMode.isEdit` instead of `Neos.Node.isLive()`

### DIFF
--- a/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
+++ b/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
@@ -1,5 +1,5 @@
 prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Fusion:Component) {
-    @if.onlyRenderWhenInLiveWorkspace = ${Neos.Node.isLive(this.node)}
+    @if.onlyRenderWhenInLiveWorkspace = ${!renderingMode.isEdit}
     @if.languageDimensionExists = ${this.dimension}
     @if.hasNoForeignCanonical = ${String.isBlank(q(this.node).property('canonicalLink'))}
 

--- a/Resources/Private/Fusion/Metadata/LangAttribute.fusion
+++ b/Resources/Private/Fusion/Metadata/LangAttribute.fusion
@@ -5,5 +5,5 @@ prototype(Neos.Seo:LangAttribute) < prototype(Neos.Fusion:Value) {
     value = ${Neos.Dimension.currentValue(documentNode, this.dimension).value}
     value.@process.replaceUnderscore = ${value ? String.replace(value, this.dimensionValueSeparator , '-') : null}
 
-    @if.onlyRenderWhenInLiveWorkspace = ${Neos.Node.isLive(documentNode)}
+    @if.onlyRenderWhenInLiveWorkspace = ${!renderingMode.isEdit}
 }


### PR DESCRIPTION
After removal of `Neos.Node.inBackend()` and `Neos.Node.isLive()` in #4542 we need to adjust the fusion conditions to work with `renderingMode` instead.

Relates: #4505
Relates: #4542
