### PR TITLE
TASK: Adjust usage of `hiddenInIndex` to use `hiddenInMenu`

### DIFF
--- a/Classes/Fusion/XmlSitemapUrlsImplementation.php
+++ b/Classes/Fusion/XmlSitemapUrlsImplementation.php
@@ -42,7 +42,7 @@ class XmlSitemapUrlsImplementation extends AbstractFusionObject
      */
     protected array $assetPropertiesByNodeType = [];
 
-    protected ?bool $renderHiddenInIndex = null;
+    protected ?bool $renderHiddenInMenu = null;
 
     protected ?bool $includeImageUrls = null;
 
@@ -62,13 +62,13 @@ class XmlSitemapUrlsImplementation extends AbstractFusionObject
         return $this->includeImageUrls;
     }
 
-    public function getRenderHiddenInIndex(): bool
+    public function getRenderHiddenInMenu(): bool
     {
-        if ($this->renderHiddenInIndex === null) {
-            $this->renderHiddenInIndex = (boolean)$this->fusionValue('renderHiddenInIndex');
+        if ($this->renderHiddenInMenu === null) {
+            $this->renderHiddenInMenu = (boolean)$this->fusionValue('renderHiddenInMenu');
         }
 
-        return $this->renderHiddenInIndex;
+        return $this->renderHiddenInMenu;
     }
 
     /**
@@ -214,13 +214,13 @@ class XmlSitemapUrlsImplementation extends AbstractFusionObject
     }
 
     /**
-     * Return TRUE/FALSE if the node is currently hidden; taking the "renderHiddenInIndex" configuration
+     * Return TRUE/FALSE if the node is currently hidden; taking the "renderHiddenInMenu" configuration
      * of the Menu Fusion object into account.
      */
     protected function isDocumentNodeToBeIndexed(Node $node): bool
     {
         return !$this->getNodeType($node)->isOfType('Neos.Seo:NoindexMixin')
-            && ($this->getRenderHiddenInIndex() || $node->getProperty('hiddenInIndex') !== true)
+            && ($this->getRenderHiddenInMenu() || $node->getProperty('hiddenInMenu') !== true)
             && $node->getProperty('metaRobotsNoindex') !== true
             && (
                 (string)$node->getProperty('canonicalLink') === ''

--- a/Resources/Private/Fusion/Helper/SitemapUrls.fusion
+++ b/Resources/Private/Fusion/Helper/SitemapUrls.fusion
@@ -2,5 +2,5 @@ prototype(Neos.Seo:Helper.SitemapUrls) {
     @class = 'Neos\\Seo\\Fusion\\XmlSitemapUrlsImplementation'
     startingPoint = null
     includeImageUrls = false
-    renderHiddenInIndex = true
+    renderHiddenInMenu = true
 }


### PR DESCRIPTION
The internal property `hiddenInIndex` was renamed to `hiddenInMenu`. To match this renaming the fusion property `renderHiddenInIndex` is renamed to `renderHiddenInMenu`.

Needs: https://github.com/neos/neos-development-collection/pull/4921
