### PR TITLE
BUGFIX: Use correct attribute name for google site verification meta tag

### DIFF
--- a/Resources/Private/Fusion/Metadata/GoogleSiteVerification.fusion
+++ b/Resources/Private/Fusion/Metadata/GoogleSiteVerification.fusion
@@ -6,7 +6,7 @@ prototype(Neos.Seo:GoogleSiteVerification) < prototype(Neos.Fusion:Component) {
 
     renderer = afx`
         <meta
-            property="google-site-verification"
+            name="google-site-verification"
             content={props.googleSiteVerification}
         />
     `


### PR DESCRIPTION
The name attribute for the google site verification was wrong, so I changed it from `<meta property="..." content="..." />` to `<meta name="..." content="..." />`. 

Also see [Verification method details > HTML Tag](https://support.google.com/webmasters/answer/9008080?hl=en#meta_tag_verification&zippy=%2Chtml-tag) on the google support.