### PR TITLE
Update github actions dependencies to latest version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     env:
       FLOW_PATH_ROOT: ../neos-base-distribution
+      PACKAGE_FOLDER: neos-seo
 
     runs-on: ubuntu-latest
 
@@ -26,6 +27,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Set package branch name
+        run: echo "PACKAGE_TARGET_VERSION=${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
+        working-directory: .
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -48,7 +53,9 @@ jobs:
           git clone --depth 1 --branch ${{ matrix.neos-version }} https://github.com/neos/neos-development-distribution.git ${FLOW_PATH_ROOT}
           cd ${FLOW_PATH_ROOT}
           composer config --no-plugins allow-plugins.neos/composer-plugin true
-          composer config repositories.package '{ "type": "path", "url": "../neos-seo", "options": { "symlink": false } }'
+
+          git -C ../${{ env.PACKAGE_FOLDER }} checkout -b ${PACKAGE_TARGET_VERSION}
+          composer config repositories.package '{ "type": "path", "url": "../${{ env.PACKAGE_FOLDER }}", "options": { "symlink": false } }'
           composer require --no-update --no-interaction neos/seo:@dev
           composer require --dev --no-update --no-interaction phpstan/phpstan:^1.10
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -37,7 +37,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
         shell: bash
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}


### PR DESCRIPTION
Update github actions:
* actions/checkout@v3 -> actions/checkout@v4
* actions/cache@v2 -> actions/cache@v4

Also fixing, the pipeline. Now it runs also on branches. Needed some quirk to fulfill the dependency requirements of the `neos/neos-base-distribution` or moreover of the required `neos/demo` package as this already require the `neos/seo` package in a given version (~4.1).