### PR TITLE
TASK: Disable tests on PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,6 @@ name: Tests
 on:
   push:
     branches: [ main, '[0-9]+.x' ]
-  pull_request:
-    branches: [ main, '[0-9]+.x' ]
   workflow_dispatch: # Allow manual triggering on any branch via `gh workflow run tests.yml -r branch-name`
 
 jobs:
@@ -53,8 +51,6 @@ jobs:
           git clone --depth 1 --branch ${{ matrix.neos-version }} https://github.com/neos/neos-development-distribution.git ${FLOW_PATH_ROOT}
           cd ${FLOW_PATH_ROOT}
           composer config --no-plugins allow-plugins.neos/composer-plugin true
-
-          git -C ../${{ env.PACKAGE_FOLDER }} checkout -b ${PACKAGE_TARGET_VERSION}
           composer config repositories.package '{ "type": "path", "url": "../${{ env.PACKAGE_FOLDER }}", "options": { "symlink": false } }'
           composer require --no-update --no-interaction neos/seo:@dev
           composer require --dev --no-update --no-interaction phpstan/phpstan:^1.10


### PR DESCRIPTION
The current setup doesn't allow to run the tests within a PR.

The tests try to install the `neos/neos-development-distribution` which requires the `neos/demo` package. The `neos/demo` package requires the `neos/seo` with version `~4.1`.

For running the tests we need to checkout the `neos/seo` version outside of this constraint. As this is a dependency of a required package, we can't alias or override this here easily.

See: 
* https://github.com/neos/neos-development-distribution/blob/9.0/composer.json#L30
* https://github.com/neos/Neos.Demo/blob/9.0/composer.json#L16