### PR TITLE
BUGFIX: Correct dimension handling for fallback nodes in Neos 9.x

### DIFF
--- a/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
+++ b/Resources/Private/Fusion/Metadata/AlternateLanguageLinks.fusion
@@ -23,12 +23,15 @@ prototype(Neos.Seo:AlternateLanguageLinks) < prototype(Neos.Fusion:Component) {
 
             node = ${Neos.Dimension.findVariantInDimension(props.node, props.dimension, dimensionValue)}
             dimensionValueSeparator = ${props.dimensionValueSeparator}
+            dimension = ${props.dimension}
 
             renderer = afx`
                 <Neos.Seo:AlternateLanguageLink @key="defaultLink" node={props.node} hreflang="x-default"
                                                 @if.isFirst={iteration.isFirst}/>
                 <Neos.Seo:AlternateLanguageLink node={props.node}
-                    hreflang={String.replace(dimensionValue.value, props.dimensionValueSeparator, '-')}/>
+                    hreflang={String.replace(dimensionValue.value, props.dimensionValueSeparator, '-')}
+                    @if.isNoFallback={Neos.Dimension.currentValue(props.node, props.dimension) == Neos.Dimension.originValue(props.node, props.dimension)}
+                />
             `
         }
     }

--- a/Resources/Private/Fusion/Metadata/CanonicalLink.fusion
+++ b/Resources/Private/Fusion/Metadata/CanonicalLink.fusion
@@ -3,7 +3,17 @@ prototype(Neos.Seo:CanonicalLink) < prototype(Neos.Fusion:Tag) {
     attributes {
         rel = 'canonical'
         href = Neos.Fusion:Component {
-            node = ${documentNode}
+            node = Neos.Fusion:Case {
+                useFallback {
+                    condition = ${documentNode.originDimensionSpacePoint.hash != documentNode.dimensionSpacePoint.hash}
+                    renderer = ${q(documentNode).context({dimensions: NeosIo.Node.dimensionSpacePointArray(documentNode.originDimensionSpacePoint)}).get(0)}
+                }
+                default {
+                    condition = true
+                    renderer = ${documentNode}
+                }
+            }
+
             canonicalLink = ${q(this.node).property('canonicalLink')}
 
             renderer = Neos.Fusion:Case {

--- a/Resources/Private/Fusion/Metadata/LangAttribute.fusion
+++ b/Resources/Private/Fusion/Metadata/LangAttribute.fusion
@@ -2,7 +2,7 @@ prototype(Neos.Seo:LangAttribute) < prototype(Neos.Fusion:Value) {
     dimension = 'language'
     dimensionValueSeparator = '_'
 
-    value = ${Neos.Dimension.currentValue(documentNode, this.dimension).value}
+    value = ${Neos.Dimension.originValue(documentNode, this.dimension).value}
     value.@process.replaceUnderscore = ${value ? String.replace(value, this.dimensionValueSeparator , '-') : null}
 
     @if.onlyRenderWhenInLiveWorkspace = ${!renderingMode.isEdit}


### PR DESCRIPTION
Uses the origin dimension value spacepoints to determine:
* Language attribute of the document node
* Canonical URL
* Alternative URLs

Fixes #198